### PR TITLE
feat: Allow tokenizer to be used to count tokens and limit tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ pub trait EmbeddingBase<S: AsRef<str>> {
 
 /// Rust representation of the FlagEmbedding model
 pub struct FlagEmbedding {
-    tokenizer: Tokenizer,
+    pub tokenizer: Tokenizer,
     session: Session,
     model: EmbeddingModel,
 }


### PR DESCRIPTION
Right now the tokenizer is private, so it can't be used to count the number of tokens in a passage or to chunk passages to a specific token limit.

This PR moves towards resolving that.