### PR TITLE
fix: do not commit an environment on each model create

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,11 +209,8 @@ impl FlagEmbedding {
         let model_path =
             FlagEmbedding::retrieve_model(model_name.clone(), &cache_dir, show_download_message)?;
 
-        ort::init()
-            .with_name("Fastembed")
-            .with_execution_providers(execution_providers)
-            .commit()?;
         let session = Session::builder()?
+            .with_execution_providers(execution_providers)?
             .with_optimization_level(GraphOptimizationLevel::Level3)?
             .with_intra_threads(threads)?
             .with_model_from_file(model_path.join("model_optimized.onnx"))?;


### PR DESCRIPTION
Libraries shouldn't commit an environment themselves as it would be impossible or inconvenient to provide environment options, and since only one environment is allowed in a program at a time, an environment should only ever be committed once.

If an environment is not committed by the time a session is created, a default one will be created, so there is no need for `fastembed` to commit its own environment here.