### PR TITLE
chore: update ort to 2.0.0-rc.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            ~/.cache/ort.pyke.io
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 

--- a/.releaserc
+++ b/.releaserc
@@ -59,7 +59,7 @@
           },
           {
             "type": "chore",
-            "release": false
+            "release": "patch"
           }
         ]
       }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +161,19 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -711,10 +733,11 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "ort"
-version = "2.0.0-alpha.4"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdb7c4723330322ea09d508e730950e4fcf2116f2dc8394ca0f00dbb77e9e11"
+checksum = "f8e5caf4eb2ead4bc137c3ff4e347940e3e556ceb11a4180627f04b63d7342dd"
 dependencies = [
+ "compact_str",
  "half 2.3.1",
  "ndarray",
  "ort-sys",
@@ -972,6 +995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1096,12 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,19 @@ anyhow = { version = "1.0" }
 flate2 = { version = "1.0" }
 minreq = { version = "2.10", default-features = false, features = ["https-rustls"] }
 ndarray = { version = "0.15", default-features = false }
-ort = { version = "2.0.0-alpha.4", default-features = false, features = [ "ndarray", "download-binaries" ] }
+ort = { version = "2.0.0-rc.0", default-features = false, features = [ "ndarray" ] }
 rayon = { version = "1.7", default-features = false }
 serde_json = {version = "1"}
 tar = { version = "0.4", default-features = false }
 tokenizers = { version = "0.14", default-features = false, features = ["onig"]}
 
 [dev-dependencies]
-ort = "2.0.0-alpha.4"
+ort = "2.0.0-rc.0"
 criterion = "0.5.1"
+
+[features]
+default = ["ort-download-binaries"]
+ort-download-binaries = ["ort/download-binaries"]
 
 [[bench]]
 name="embed"


### PR DESCRIPTION
Updates `ort` to v2.0.0-rc.0.

Also gates enabling `ort`'s `download-binaries` feature behind a (default) feature, which can now be disabled in case the user doesn't want to use downloaded binaries.