### PR TITLE
fix: full offline model retrieval (from cache)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ rayon = { version = "1.7", default-features = false }
 serde_json = {version = "1"}
 tokenizers = { version = "0.14", default-features = false, features = ["onig"]}
 variant_count = "1.1.0"
-walkdir = "2.4.0"
 
 [dev-dependencies]
 ort = "2.0.0-rc.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rayon = { version = "1.7", default-features = false }
 serde_json = {version = "1"}
 tokenizers = { version = "0.14", default-features = false, features = ["onig"]}
 variant_count = "1.1.0"
+walkdir = "2.4.0"
 
 [dev-dependencies]
 ort = "2.0.0-rc.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,6 @@ impl TextEmbedding {
                 TextEmbedding::retrieve_remote_model_file(info, &model_repo)
             }
             Err(ref e) => {
-                eprintln!("Error retrieving model info (likely no connection): {}", e);
                 eprintln!("Falling back on cached model.");
                 TextEmbedding::retrieve_cached_model_file(&model_name, &cache_dir).expect(
                     "Could not find any locally cached .onnx file for this model. Please try again with a web connection.",


### PR DESCRIPTION
This fixes #30. Previously, an attempt to access a model while offline would fail, even if that model was already cached. This is because a request was made to the remote hugging face repo to obtain the file path of the .onnx model. This change implements a fallback search over the cache dir to find the relevant model file. It there are multiple snapshots for a particular model, it would not know which is the 'correct' file - this is unlikely to be a significant problem as this is only intended to be a fallback for DX purposes.

Also exposes new public function "get_model_info" - this is primarily to give users a convenient way of accessing model dimensions.  