### PR TITLE
Made tokenizer public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://crates.io/crates/fastembed"
 anyhow = { version = "1.0" }
 hf-hub = {version="0.3", default-features = false, features = ["online"]}
 ndarray = { version = "0.15", default-features = false }
-ort = { version = "2.0.0-rc.0", features = [ "ndarray" ] }
+ort = { git = "https://github.com/pykeio/ort.git", rev = "2abc210f3958c5b94528cc71c6c8781813a2cc2f", features = [ "ndarray" ] }
 rayon = { version = "1.7", default-features = false }
 serde_json = {version = "1"}
 tokenizers = { version = "0.14", default-features = false, features = ["onig"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokenizers = { version = "0.14", default-features = false, features = ["onig"]}
 variant_count = "1.1.0"
 
 [dev-dependencies]
-ort = "2.0.0-rc.0"
+ort = {git = "https://github.com/pykeio/ort.git", rev = "2abc210f3958c5b94528cc71c6c8781813a2cc2f"}
 criterion = "0.5.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ homepage = "https://crates.io/crates/fastembed"
 anyhow = { version = "1.0" }
 hf-hub = {version="0.3", default-features = false, features = ["online"]}
 ndarray = { version = "0.15", default-features = false }
-ort = { git = "https://github.com/pykeio/ort.git", rev = "2abc210f3958c5b94528cc71c6c8781813a2cc2f", features = [ "ndarray" ] }
+ort = { version = "2.0.0-rc.0", features = [ "ndarray" ] }
 rayon = { version = "1.7", default-features = false }
 serde_json = {version = "1"}
 tokenizers = { version = "0.14", default-features = false, features = ["onig"]}
 variant_count = "1.1.0"
 
 [dev-dependencies]
-ort = {git = "https://github.com/pykeio/ort.git", rev = "2abc210f3958c5b94528cc71c6c8781813a2cc2f"}
+ort = "2.0.0-rc.0"
 criterion = "0.5.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://crates.io/crates/fastembed"
 anyhow = { version = "1.0" }
 hf-hub = {version="0.3", default-features = false, features = ["online"]}
 ndarray = { version = "0.15", default-features = false }
-ort = { version = "2.0.0-rc.0", default-features = false, features = [ "ndarray" ] }
+ort = { version = "2.0.0-rc.0", features = [ "ndarray" ] }
 rayon = { version = "1.7", default-features = false }
 serde_json = {version = "1"}
 tokenizers = { version = "0.14", default-features = false, features = ["onig"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub struct ModelInfo {
 
 /// Rust representation of the TextEmbedding model
 pub struct TextEmbedding {
-    tokenizer: Tokenizer,
+    pub tokenizer: Tokenizer,
     session: Session,
 }
 


### PR DESCRIPTION
The tokenizer should be public so it can be accessed for things like calculating token count.