### PR TITLE
chore: bump ort to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://crates.io/crates/fastembed"
 anyhow = { version = "1" }
 hf-hub = {version="0.3", default-features = false, features = ["online"]}
 ndarray = { version = "0.15", default-features = false }
-ort = { version = "=2.0.0-rc.2", default-features = false, features = [ "ndarray" ] }
+ort = { version = "=2.0.0-rc.4", default-features = false, features = [ "ndarray" ] }
 rayon = { version = "1.10", default-features = false }
 serde_json = {version = "1"}
 tokenizers = { version = "0.19", default-features = false, features = ["onig"]}


### PR DESCRIPTION
Fixes #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `ort` dependency version from `2.0.0-rc.2` to `2.0.0-rc.4` for improved stability and latest features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->