### PR TITLE
refactor: Use hardcoding of `last_hidden_state` only if multiple output nodes exist

### DIFF
--- a/src/text_embedding.rs
+++ b/src/text_embedding.rs
@@ -277,6 +277,13 @@ impl TextEmbedding {
 
                 let outputs = self.session.run(session_inputs)?;
 
+                // Try to get the only output key
+                // If multiple, then default to `last_hidden_state`
+                let last_hidden_state_key = match outputs.len() {
+                    1 => outputs.keys().next().unwrap(),
+                    _ => "last_hidden_state",
+                };
+
                 // Extract and normalize embeddings
                 let output_data = outputs["last_hidden_state"].try_extract_tensor::<f32>()?;
 

--- a/src/text_embedding.rs
+++ b/src/text_embedding.rs
@@ -285,7 +285,7 @@ impl TextEmbedding {
                 };
 
                 // Extract and normalize embeddings
-                let output_data = outputs["last_hidden_state"].try_extract_tensor::<f32>()?;
+                let output_data = outputs[last_hidden_state_key].try_extract_tensor::<f32>()?;
 
                 let embeddings: Vec<Vec<f32>> = output_data
                     .slice(s![.., 0, ..])


### PR DESCRIPTION
This PR changes the behaviour of the `get_model_info` function to try to use the only output node available. If there are multiple, then default to `last_hidden_state` as per previous behaviour.

Allows easier use of the library with ONNX models from disparate sources.

Resolves #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of multiple output keys in text embeddings, defaulting to `last_hidden_state` for better consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->