### PR TITLE
chore: Export error type

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -11,6 +11,9 @@ pub const DEFAULT_CACHE_DIR: &str = ".fastembed_cache";
 /// Type alias for the embedding vector
 pub type Embedding = Vec<f32>;
 
+/// Type alias for the error type
+pub type Error = anyhow::Error;
+
 // Tokenizer files for "bring your own" models
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TokenizerFiles {

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,6 +12,7 @@ pub const DEFAULT_CACHE_DIR: &str = ".fastembed_cache";
 pub type Embedding = Vec<f32>;
 
 /// Type alias for the error type
+#[allow(dead_code)]
 pub type Error = anyhow::Error;
 
 // Tokenizer files for "bring your own" models

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,7 +12,6 @@ pub const DEFAULT_CACHE_DIR: &str = ".fastembed_cache";
 pub type Embedding = Vec<f32>;
 
 /// Type alias for the error type
-#[allow(dead_code)]
 pub type Error = anyhow::Error;
 
 // Tokenizer files for "bring your own" models

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod tests;
 
 pub use ort::ExecutionProviderDispatch;
 
-pub use crate::common::{read_file_to_bytes, Error, Embedding, TokenizerFiles};
+pub use crate::common::{read_file_to_bytes, Embedding, Error, TokenizerFiles};
 pub use crate::models::reranking::{RerankerModel, RerankerModelInfo};
 pub use crate::models::text_embedding::{EmbeddingModel, ModelInfo};
 pub use crate::reranking::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod tests;
 
 pub use ort::ExecutionProviderDispatch;
 
-pub use crate::common::{read_file_to_bytes, Embedding, TokenizerFiles};
+pub use crate::common::{read_file_to_bytes, Error, Embedding, TokenizerFiles};
 pub use crate::models::reranking::{RerankerModel, RerankerModelInfo};
 pub use crate::models::text_embedding::{EmbeddingModel, ModelInfo};
 pub use crate::reranking::{


### PR DESCRIPTION
The error type is exposed in the public API (for example, by the return type of `load_tokenizer`) but right now I can't refer to it without adding a dependency on `anyhow` myself.