### PR TITLE
fix: Splade sparse vectors should exclude zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The default model is Flag Embedding, which is top of the [MTEB](https://huggingf
 - [**Alibaba-NLP/gte-base-en-v1.5**](https://huggingface.co/Alibaba-NLP/gte-base-en-v1.5)
 - [**Alibaba-NLP/gte-large-en-v1.5**](https://huggingface.co/Alibaba-NLP/gte-large-en-v1.5)
 
-## Sparse vectors
+### Sparse Text Embedding
 
 - [**prithivida/Splade_PP_en_v1**](https://huggingface.co/prithivida/Splade_PP_en_v1) - Default
 

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -3,7 +3,7 @@ use ndarray::{ArrayViewD, Axis, CowArray, Dim};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SparseModel {
-    /// Splade PP Sparse vector model Qdrant/Splade_PP_en_v1
+    /// prithivida/Splade_PP_en_v1
     SPLADEPPV1,
 }
 

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -46,7 +46,7 @@ impl SparseModel {
                         let mut indices: Vec<usize> = Vec::new();
 
                         row_scores.into_iter().enumerate().for_each(|(idx, f)| {
-                            if f >= &f32::MIN_POSITIVE {
+                            if f > 0.0 {
                                 values.push(*f);
                                 indices.push(idx);
                             }

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -46,7 +46,7 @@ impl SparseModel {
                         let mut indices: Vec<usize> = Vec::new();
 
                         row_scores.into_iter().enumerate().for_each(|(idx, f)| {
-                            if f.is_sign_positive() {
+                            if f >= &f32::MIN_POSITIVE {
                                 values.push(*f);
                                 indices.push(idx);
                             }

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -41,12 +41,11 @@ impl SparseModel {
                     .rows()
                     .into_iter()
                     .map(|row_scores| {
-                        let mut values: Vec<f32> = Vec::new();
-                        // Is a usize big enough?
-                        let mut indices: Vec<usize> = Vec::new();
+                        let mut values: Vec<f32> = Vec::with_capacity(scores.len());
+                        let mut indices: Vec<usize> = Vec::with_capacity(scores.len());
 
                         row_scores.into_iter().enumerate().for_each(|(idx, f)| {
-                            if f > 0.0 {
+                            if *f > 0.0 {
                                 values.push(*f);
                                 indices.push(idx);
                             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -61,7 +61,8 @@ fn test_sparse_embeddings() {
 
             assert_eq!(embeddings.len(), documents.len());
             embeddings.into_iter().for_each(|embedding| {
-                assert_eq!(embedding.indices.len(), 20);
+                assert!(embedding.values.iter().all(|&v| v > 0.0));
+                assert!(embedding.indices.len() < 100);
                 assert_eq!(embedding.indices.len(), embedding.values.len());
             });
         });

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,9 +60,10 @@ fn test_sparse_embeddings() {
             let embeddings = model.embed(documents.clone(), None).unwrap();
 
             assert_eq!(embeddings.len(), documents.len());
-            for embedding in embeddings {
+            embeddings.into_iter().for_each(|(embedding, tokens)| {
+                assert_eq!(embedding.indices.len(), 20);
                 assert_eq!(embedding.indices.len(), embedding.values.len());
-            }
+            });
         });
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,7 +60,7 @@ fn test_sparse_embeddings() {
             let embeddings = model.embed(documents.clone(), None).unwrap();
 
             assert_eq!(embeddings.len(), documents.len());
-            embeddings.into_iter().for_each(|(embedding, tokens)| {
+            embeddings.into_iter().for_each(|embedding| {
                 assert_eq!(embedding.indices.len(), 20);
                 assert_eq!(embedding.indices.len(), embedding.values.len());
             });
@@ -185,8 +185,8 @@ fn test_rerank() {
             .unwrap();
 
         assert_eq!(results.len(), documents.len());
-        assert!(results[0].document.as_ref().unwrap() == "panda is an animal");
-        assert!(results[1].document.as_ref().unwrap() == "The giant panda, sometimes called a panda bear or simply panda, is a bear species endemic to China.");
+        assert_eq!(results[0].document.as_ref().unwrap(), "panda is an animal");
+        assert_eq!(results[1].document.as_ref().unwrap(), "The giant panda, sometimes called a panda bear or simply panda, is a bear species endemic to China.");
     });
 }
 


### PR DESCRIPTION
I made an oopsie. `is_sign_positive` also accounts for `+0.00`, which is incorrect and resulted in max size (30522) vectors. This fixes the issue.