### PR TITLE
patch: expose Pooling config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,5 @@ pub use crate::sparse_text_embedding::{SparseInitOptions, SparseTextEmbedding};
 pub use crate::text_embedding::{
     InitOptions, InitOptionsUserDefined, TextEmbedding, UserDefinedEmbeddingModel,
 };
+
+pub use crate::pooling::Pooling;


### PR DESCRIPTION
This is so that consumer can initialise user defined mode. My bad, this should have gone into the previous PR.