### PR TITLE
fix!: Throws an informative error upon inappropriate batch size with Dynamic Quantized models

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,9 @@ pub use crate::common::{
     read_file_to_bytes, Embedding, Error, SparseEmbedding, TokenizerFiles, DEFAULT_CACHE_DIR,
 };
 pub use crate::models::reranking::{RerankerModel, RerankerModelInfo};
-pub use crate::models::{model_info::ModelInfo, text_embedding::EmbeddingModel};
+pub use crate::models::{
+    model_info::ModelInfo, quantization::QuantizationMode, text_embedding::EmbeddingModel,
+};
 pub use crate::output::{EmbeddingOutput, OutputKey, OutputPrecedence, SingleBatchOutput};
 pub use crate::pooling::Pooling;
 pub use crate::reranking::{

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod model_info;
+pub mod quantization;
 pub mod reranking;
 pub mod sparse;
 pub mod text_embedding;

--- a/src/models/quantization.rs
+++ b/src/models/quantization.rs
@@ -1,0 +1,13 @@
+/// Enum for quantization mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizationMode {
+    None,
+    Static,
+    Dynamic,
+}
+
+impl Default for QuantizationMode {
+    fn default() -> Self {
+        Self::None
+    }
+}

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -2,7 +2,14 @@ use crate::pooling::Pooling;
 
 use super::model_info::ModelInfo;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+use super::quantization::QuantizationMode;
+
+use std::{collections::HashMap, sync::OnceLock};
+
+/// Lazy static list of all available models.
+static MODEL_MAP: OnceLock<HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EmbeddingModel {
     /// sentence-transformers/all-MiniLM-L6-v2
     AllMiniLML6V2,
@@ -58,7 +65,8 @@ pub enum EmbeddingModel {
     GTELargeENV15Q,
 }
 
-pub fn models_list() -> Vec<ModelInfo<EmbeddingModel>> {
+/// Centralized function to initialize the models map.
+fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
     let models_list = vec![
         ModelInfo {
             model: EmbeddingModel::AllMiniLML6V2,
@@ -258,6 +266,30 @@ pub fn models_list() -> Vec<ModelInfo<EmbeddingModel>> {
     // );
 
     models_list
+        .into_iter()
+        .fold(HashMap::new(), |mut map, model| {
+            // Insert the model into the map
+            map.insert(model.model.clone(), model);
+            map
+        })
+}
+
+/// Get a map of all available models.
+pub fn models_map() -> &'static HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
+    MODEL_MAP.get_or_init(init_models_map)
+}
+
+/// Get model information by model code.
+pub fn get_model_info(model: &EmbeddingModel) -> Option<&ModelInfo<EmbeddingModel>> {
+    models_map().get(model)
+}
+
+/// Get a list of all available models.
+///
+/// This will assign new memory to the models list; where possible, use
+/// [`models_map`] instead.
+pub fn models_list() -> Vec<ModelInfo<EmbeddingModel>> {
+    models_map().values().cloned().collect()
 }
 
 impl EmbeddingModel {
@@ -295,6 +327,35 @@ impl EmbeddingModel {
             EmbeddingModel::GTEBaseENV15Q => Some(Pooling::Cls),
             EmbeddingModel::GTELargeENV15 => Some(Pooling::Cls),
             EmbeddingModel::GTELargeENV15Q => Some(Pooling::Cls),
+        }
+    }
+
+    /// Get the quantization mode of the model.
+    ///
+    /// Any models with a `Q` suffix in their name are quantized models.
+    ///
+    /// Currently only 6 supported models have dynamic quantization:
+    /// - Alibaba-NLP/gte-base-en-v1.5
+    /// - Alibaba-NLP/gte-large-en-v1.5
+    /// - mixedbread-ai/mxbai-embed-large-v1
+    /// - nomic-ai/nomic-embed-text-v1.5
+    /// - Xenova/all-MiniLM-L12-v2
+    /// - Xenova/all-MiniLM-L6-v2
+    ///
+    // TODO: Update this list when more models are added
+    pub fn get_quantization_mode(&self) -> QuantizationMode {
+        match self {
+            EmbeddingModel::AllMiniLML6V2Q => QuantizationMode::Dynamic,
+            EmbeddingModel::AllMiniLML12V2Q => QuantizationMode::Dynamic,
+            EmbeddingModel::BGEBaseENV15Q => QuantizationMode::Static,
+            EmbeddingModel::BGELargeENV15Q => QuantizationMode::Static,
+            EmbeddingModel::BGESmallENV15Q => QuantizationMode::Static,
+            EmbeddingModel::NomicEmbedTextV15Q => QuantizationMode::Dynamic,
+            EmbeddingModel::ParaphraseMLMiniLML12V2Q => QuantizationMode::Static,
+            EmbeddingModel::MxbaiEmbedLargeV1Q => QuantizationMode::Dynamic,
+            EmbeddingModel::GTEBaseENV15Q => QuantizationMode::Dynamic,
+            EmbeddingModel::GTELargeENV15Q => QuantizationMode::Dynamic,
+            _ => QuantizationMode::None,
         }
     }
 }

--- a/src/text_embedding/init.rs
+++ b/src/text_embedding/init.rs
@@ -4,7 +4,7 @@
 use crate::{
     common::{TokenizerFiles, DEFAULT_CACHE_DIR},
     pooling::Pooling,
-    EmbeddingModel,
+    EmbeddingModel, QuantizationMode,
 };
 use ort::ExecutionProviderDispatch;
 use std::path::{Path, PathBuf};
@@ -71,4 +71,5 @@ pub struct UserDefinedEmbeddingModel {
     pub onnx_file: Vec<u8>,
     pub tokenizer_files: TokenizerFiles,
     pub pooling: Option<Pooling>,
+    pub quantization: QuantizationMode,
 }

--- a/tests/optimum_cli_export.rs
+++ b/tests/optimum_cli_export.rs
@@ -10,7 +10,8 @@
 use std::{path::PathBuf, process};
 
 use fastembed::{
-    Pooling, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel, DEFAULT_CACHE_DIR,
+    Pooling, QuantizationMode, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
+    DEFAULT_CACHE_DIR,
 };
 
 const EPS: f32 = 1e-4;
@@ -66,6 +67,7 @@ fn load_model(output: &PathBuf, pooling: Option<Pooling>) -> anyhow::Result<Text
             tokenizer_config_file: load_bytes_from_file(&output.join("tokenizer_config.json"))?,
         },
         pooling,
+        quantization: QuantizationMode::None,
     };
 
     TextEmbedding::try_new_from_user_defined(model, Default::default())


### PR DESCRIPTION
## Motivation

Closes #107, at least as the short term solution.

`EmbeddingModel` now has a `get_quantization_mode` method which will return static values for the models behaviour. Not all quantized models are affected, thus we need to tell apart the non-quantized, static quantized and dynamic quantized.

Batch size will then be checked upon `transform` to see if the batch size is appropriate; if not, returns an `Err` stating the reason for it.

Also contains a minor refactor of `text_embedding.rs`, bringing the `models_list` into static scope, not requiring repeated instantiation every time `models_list` is called. This is done via `std::sync::OnceLock`. Also provides a convenient function `get_model_info`, which is an `O(1)` lookup with no memory cost to get the correct model if exists.

## Test Plan

`cargo test --features=optimum-cli`.

The `test_embeddings` test had been split into two via a `macro_rules`, one for `None` batch size and the other for `Some(3)`. Internally `test_embeddings` will check if the batch size is appropriate, and expects an `Err` instead. For non-quantized and static quantized models, the pre-calculated embeddings sum still need to be satisfied with or without batch size.

## Breaking changes

`quantization` parameter had been added to `UserDefinedEmbeddingModel`, which cannot otherwise be inferred.
