### PR TITLE
chore: bump ort to =2.0.0-rc.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ homepage = "https://crates.io/crates/fastembed"
 anyhow = { version = "1" }
 hf-hub = { version = "0.3", default-features = false }
 image = "0.25.2"
-ndarray = { version = "0.15", default-features = false }
-ort = { version = "=2.0.0-rc.4", default-features = false, features = [
+ndarray = { version = "0.16", default-features = false }
+ort = { version = "=2.0.0-rc.5", default-features = false, features = [
     "ndarray",
 ] }
 rayon = { version = "1.10", default-features = false }

--- a/src/image_embedding/utils.rs
+++ b/src/image_embedding/utils.rs
@@ -141,10 +141,10 @@ impl Transform for Normalize {
     fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
         let array = data.array()?;
         let mean = Array::from_vec(self.mean.clone())
-            .into_shape((3, 1, 1))
+            .into_shape_with_order((3, 1, 1))
             .unwrap();
         let std = Array::from_vec(self.std.clone())
-            .into_shape((3, 1, 1))
+            .into_shape_with_order((3, 1, 1))
             .unwrap();
 
         let shape = array.shape().to_vec();


### PR DESCRIPTION
https://github.com/pykeio/ort/commit/92541cddcbcb21e28fe9466162b0f2fc7ae017ba

To hopefully fix https://github.com/Anush008/fastembed-rs/actions/runs/10442994580/job/28915920144