### PR TITLE
Fixes TODO: If more models need .onnx_data, implement a better way to…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ image = "0.25.2"
 ndarray = { version = "0.16", default-features = false }
 ort = { version = "=2.0.0-rc.5", default-features = false, features = [
     "ndarray",
+    "cuda"
 ] }
 rayon = { version = "1.10", default-features = false }
 serde_json = { version = "1" }

--- a/examples/test_bgem3.rs
+++ b/examples/test_bgem3.rs
@@ -1,0 +1,34 @@
+use fastembed::{TextEmbedding, InitOptions, EmbeddingModel};
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let options = InitOptions::new(EmbeddingModel::BGEM3)
+        .with_show_download_progress(true);
+
+    let model = TextEmbedding::try_new(options)?;
+
+    let documents = vec![
+        "fastembed-rs is licensed under Apache  2.0",
+        "embeddings are vectors",
+        "rust is a systems programming language",
+        "python is a high-level programming language",
+        "javascript is a scripting language",
+        "php is a server-side scripting language",
+        "c# is a programming language",
+        "c++ is a programming language",
+        "c is a programming language",
+        "c++ is a programming language",
+        "c is a programming language",
+    ];
+
+    let start = Instant::now();
+    let embeddings = model.embed(documents, None)?;
+    let duration = start.elapsed();
+
+    println!("Inference time: {:?}", duration);
+    println!("Embeddings length: {}", embeddings.len());
+    println!("Embedding dimension: {}", embeddings[0].len());
+    println!("Embeddings: {:?}", embeddings[0]);
+
+    Ok(())
+}

--- a/src/image_embedding/impl.rs
+++ b/src/image_embedding/impl.rs
@@ -47,12 +47,20 @@ impl ImageEmbedding {
             show_download_progress,
         )?;
 
+        let model_info = ImageEmbedding::get_model_info(&model_name);
+
+        for additional_file in &model_info.additional_files {
+            model_repo
+                .get(additional_file)
+                .unwrap_or_else(|_| panic!("Failed to retrieve {}", additional_file));
+        }
+
         let preprocessor_file = model_repo
             .get("preprocessor_config.json")
             .unwrap_or_else(|_| panic!("Failed to retrieve preprocessor_config.json"));
         let preprocessor = Compose::from_file(preprocessor_file)?;
 
-        let model_file_name = ImageEmbedding::get_model_info(&model_name).model_file;
+        let model_file_name = model_info.model_file;
         let model_file_reference = model_repo
             .get(&model_file_name)
             .unwrap_or_else(|_| panic!("Failed to retrieve {} ", model_file_name));

--- a/src/models/image_embedding.rs
+++ b/src/models/image_embedding.rs
@@ -22,6 +22,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("CLIP vision encoder based on ViT-B/32"),
             model_code: String::from("Qdrant/clip-ViT-B-32-vision"),
             model_file: String::from("model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: ImageEmbeddingModel::Resnet50,
@@ -29,6 +30,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("ResNet-50 from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`__."),
             model_code: String::from("Qdrant/resnet50-onnx"),
             model_file: String::from("model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: ImageEmbeddingModel::UnicomVitB16,
@@ -36,6 +38,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("Unicom Unicom-ViT-B-16 from open-metric-learning"),
             model_code: String::from("Qdrant/Unicom-ViT-B-16"),
             model_file: String::from("model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: ImageEmbeddingModel::UnicomVitB32,
@@ -43,6 +46,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("Unicom Unicom-ViT-B-32 from open-metric-learning"),
             model_code: String::from("Qdrant/Unicom-ViT-B-32"),
             model_file: String::from("model.onnx"),
+            additional_files: vec![],
         }
     ];
 

--- a/src/models/model_info.rs
+++ b/src/models/model_info.rs
@@ -6,4 +6,5 @@ pub struct ModelInfo<T> {
     pub description: String,
     pub model_code: String,
     pub model_file: String,
+    pub additional_files: Vec<String>,
 }

--- a/src/models/reranking.rs
+++ b/src/models/reranking.rs
@@ -17,18 +17,21 @@ pub fn reranker_model_list() -> Vec<RerankerModelInfo> {
             description: String::from("reranker model for English and Chinese"),
             model_code: String::from("BAAI/bge-reranker-base"),
             model_file: String::from("onnx/model.onnx"),
-        },
+            additional_files: vec![],
+        },  
         RerankerModelInfo {
             model: RerankerModel::JINARerankerV1TurboEn,
             description: String::from("reranker model for English"),
             model_code: String::from("jinaai/jina-reranker-v1-turbo-en"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         RerankerModelInfo {
             model: RerankerModel::JINARerankerV2BaseMultiligual,
             description: String::from("reranker model for multilingual"),
             model_code: String::from("jinaai/jina-reranker-v2-base-multilingual"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
     ];
     reranker_model_list
@@ -41,6 +44,7 @@ pub struct RerankerModelInfo {
     pub description: String,
     pub model_code: String,
     pub model_file: String,
+    pub additional_files: Vec<String>,
 }
 
 impl Display for RerankerModel {

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -16,6 +16,7 @@ pub fn models_list() -> Vec<ModelInfo<SparseModel>> {
         description: String::from("Splade sparse vector model for commercial use, v1"),
         model_code: String::from("Qdrant/Splade_PP_en_v1"),
         model_file: String::from("model.onnx"),
+        additional_files: vec![],
     }]
 }
 

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -63,6 +63,8 @@ pub enum EmbeddingModel {
     GTELargeENV15,
     /// Quantized Alibaba-NLP/gte-large-en-v1.5
     GTELargeENV15Q,
+    /// BAAI/bge-m3
+    BGEM3
 }
 
 /// Centralized function to initialize the models map.
@@ -74,6 +76,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Sentence Transformer model, MiniLM-L6-v2"),
             model_code: String::from("Qdrant/all-MiniLM-L6-v2-onnx"),
             model_file: String::from("model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::AllMiniLML6V2Q,
@@ -81,6 +84,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Sentence Transformer model, MiniLM-L6-v2"),
             model_code: String::from("Xenova/all-MiniLM-L6-v2"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::AllMiniLML12V2,
@@ -88,6 +92,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Sentence Transformer model, MiniLM-L12-v2"),
             model_code: String::from("Xenova/all-MiniLM-L12-v2"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::AllMiniLML12V2Q,
@@ -95,6 +100,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Sentence Transformer model, MiniLM-L12-v2"),
             model_code: String::from("Xenova/all-MiniLM-L12-v2"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGEBaseENV15,
@@ -102,6 +108,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the base English model"),
             model_code: String::from("Xenova/bge-base-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGEBaseENV15Q,
@@ -109,6 +116,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized v1.5 release of the large English model"),
             model_code: String::from("Qdrant/bge-base-en-v1.5-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGELargeENV15,
@@ -116,6 +124,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the large English model"),
             model_code: String::from("Xenova/bge-large-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGELargeENV15Q,
@@ -123,6 +132,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized v1.5 release of the large English model"),
             model_code: String::from("Qdrant/bge-large-en-v1.5-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGESmallENV15,
@@ -130,6 +140,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the fast and default English model"),
             model_code: String::from("Xenova/bge-small-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGESmallENV15Q,
@@ -139,6 +150,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             ),
             model_code: String::from("Qdrant/bge-small-en-v1.5-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::NomicEmbedTextV1,
@@ -146,6 +158,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("8192 context length english model"),
             model_code: String::from("nomic-ai/nomic-embed-text-v1"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::NomicEmbedTextV15,
@@ -153,6 +166,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the 8192 context length english model"),
             model_code: String::from("nomic-ai/nomic-embed-text-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::NomicEmbedTextV15Q,
@@ -162,6 +176,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             ),
             model_code: String::from("nomic-ai/nomic-embed-text-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
+                additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::ParaphraseMLMiniLML12V2Q,
@@ -169,6 +184,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Multi-lingual model"),
             model_code: String::from("Qdrant/paraphrase-multilingual-MiniLM-L12-v2-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::ParaphraseMLMiniLML12V2,
@@ -176,6 +192,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Multi-lingual model"),
             model_code: String::from("Xenova/paraphrase-multilingual-MiniLM-L12-v2"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::ParaphraseMLMpnetBaseV2,
@@ -185,6 +202,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             ),
             model_code: String::from("Xenova/paraphrase-multilingual-mpnet-base-v2"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::BGESmallZHV15,
@@ -192,6 +210,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the small Chinese model"),
             model_code: String::from("Xenova/bge-small-zh-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::MultilingualE5Small,
@@ -199,6 +218,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Small model of multilingual E5 Text Embeddings"),
             model_code: String::from("intfloat/multilingual-e5-small"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::MultilingualE5Base,
@@ -206,6 +226,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Base model of multilingual E5 Text Embeddings"),
             model_code: String::from("intfloat/multilingual-e5-base"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::MultilingualE5Large,
@@ -213,6 +234,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large model of multilingual E5 Text Embeddings"),
             model_code: String::from("Qdrant/multilingual-e5-large-onnx"),
             model_file: String::from("model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::MxbaiEmbedLargeV1,
@@ -220,6 +242,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large English embedding model from MixedBreed.ai"),
             model_code: String::from("mixedbread-ai/mxbai-embed-large-v1"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::MxbaiEmbedLargeV1Q,
@@ -227,6 +250,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large English embedding model from MixedBreed.ai"),
             model_code: String::from("mixedbread-ai/mxbai-embed-large-v1"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::GTEBaseENV15,
@@ -234,6 +258,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-base-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::GTEBaseENV15Q,
@@ -241,6 +266,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-base-en-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::GTELargeENV15,
@@ -248,6 +274,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-large-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         ModelInfo {
             model: EmbeddingModel::GTELargeENV15Q,
@@ -255,7 +282,16 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-large-en-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec![],
         },
+        ModelInfo {
+            model: EmbeddingModel::BGEM3,
+            dim: 1024,
+            description: String::from("Large multilingual embedding model from BAAI"),
+            model_code: String::from("BAAI/bge-m3"),
+            model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![String::from("onnx/model.onnx_data")],
+        }
     ];
 
     // TODO: Use when out in stable
@@ -327,6 +363,8 @@ impl EmbeddingModel {
             EmbeddingModel::GTEBaseENV15Q => Some(Pooling::Cls),
             EmbeddingModel::GTELargeENV15 => Some(Pooling::Cls),
             EmbeddingModel::GTELargeENV15Q => Some(Pooling::Cls),
+
+            EmbeddingModel::BGEM3 => Some(Pooling::Cls),
         }
     }
 

--- a/src/reranking/impl.rs
+++ b/src/reranking/impl.rs
@@ -66,7 +66,15 @@ impl TextRerank {
             .expect("Failed to build API from cache");
         let model_repo = api.model(model_name.to_string());
 
-        let model_file_name = TextRerank::get_model_info(&model_name).model_file;
+        let model_info = TextRerank::get_model_info(&model_name);
+
+        for additional_file in &model_info.additional_files {
+            model_repo
+                .get(additional_file)
+                .unwrap_or_else(|_| panic!("Failed to retrieve {}", additional_file));
+        }
+
+        let model_file_name = model_info.model_file;
         let model_file_reference = model_repo
             .get(&model_file_name)
             .unwrap_or_else(|_| panic!("Failed to retrieve model file: {}", model_file_name));

--- a/src/sparse_text_embedding/impl.rs
+++ b/src/sparse_text_embedding/impl.rs
@@ -52,7 +52,15 @@ impl SparseTextEmbedding {
             show_download_progress,
         )?;
 
-        let model_file_name = SparseTextEmbedding::get_model_info(&model_name).model_file;
+        let model_info = SparseTextEmbedding::get_model_info(&model_name);
+
+        for additional_file in &model_info.additional_files {
+            model_repo
+                .get(additional_file)
+                .unwrap_or_else(|_| panic!("Failed to retrieve {}", additional_file));
+        }
+
+        let model_file_name = model_info.model_file;
         let model_file_reference = model_repo
             .get(&model_file_name)
             .unwrap_or_else(|_| panic!("Failed to retrieve {} ", model_file_name));

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -55,18 +55,17 @@ impl TextEmbedding {
         )?;
 
         let model_info = TextEmbedding::get_model_info(&model_name)?;
+
+        for additional_file in &model_info.additional_files {
+            model_repo
+                .get(additional_file)
+                .unwrap_or_else(|_| panic!("Failed to retrieve {}", additional_file));
+        }
+
         let model_file_name = &model_info.model_file;
         let model_file_reference = model_repo
             .get(model_file_name)
-            .unwrap_or_else(|_| panic!("Failed to retrieve {} ", model_file_name));
-
-        // TODO: If more models need .onnx_data, implement a better way to handle this
-        // Probably by adding `additional_files` field in the `ModelInfo` struct
-        if model_name == EmbeddingModel::MultilingualE5Large {
-            model_repo
-                .get("model.onnx_data")
-                .expect("Failed to retrieve model.onnx_data.");
-        }
+            .unwrap_or_else(|_| panic!("Failed to retrieve {}", model_file_name));
 
         // prioritise loading pooling config if available, if not (thanks qdrant!), look for it in hardcoded
         let post_processing = model_name.get_default_pooling_method();


### PR DESCRIPTION
Fixes TODO: If more models need .onnx_data, implement a better way to handle this. Probably by adding `additional_files` field in the `ModelInfo` struct.

Is able to run bge-m3 embedding model in the example.