### PR TITLE
feat: Support for bge-reranker-v2-m3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ authors = [
   "Timon Vonk <mail@timonv.nl>",
   "Luya Wang <luya.wang@qq.com>",
   "Tri <tri@triandco.com>",
-  "Denny Wong <denwong47@hotmail.com>"
+  "Denny Wong <denwong47@hotmail.com>",
+  "Alex Rozgo <alex.rozgo@gmail.com>"
 ]
 documentation = "https://docs.rs/fastembed"
 repository = "https://github.com/Anush008/fastembed-rs"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The default model is Flag Embedding, which is top of the [MTEB](https://huggingf
 ### Reranking
 
 - [**BAAI/bge-reranker-base**](https://huggingface.co/BAAI/bge-reranker-base)
+- [**BAAI/bge-reranker-v2-m3**](https://huggingface.co/BAAI/bge-reranker-v2-m3)
 - [**jinaai/jina-reranker-v1-turbo-en**](https://huggingface.co/jinaai/jina-reranker-v1-turbo-en)
 - [**jinaai/jina-reranker-v2-base-multiligual**](https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use crate::models::{
 pub use crate::output::{EmbeddingOutput, OutputKey, OutputPrecedence, SingleBatchOutput};
 pub use crate::pooling::Pooling;
 pub use crate::reranking::{
-    RerankInitOptions, RerankInitOptionsUserDefined, RerankResult, TextRerank,
+    OnnxSource, RerankInitOptions, RerankInitOptionsUserDefined, RerankResult, TextRerank,
     UserDefinedRerankingModel,
 };
 pub use crate::sparse_text_embedding::{

--- a/src/models/reranking.rs
+++ b/src/models/reranking.rs
@@ -4,6 +4,8 @@ use std::fmt::Display;
 pub enum RerankerModel {
     /// BAAI/bge-reranker-base
     BGERerankerBase,
+    /// rozgo/bge-reranker-v2-m3
+    BGERerankerV2M3,
     /// jinaai/jina-reranker-v1-turbo-en
     JINARerankerV1TurboEn,
     /// jinaai/jina-reranker-v2-base-multilingual
@@ -17,18 +19,28 @@ pub fn reranker_model_list() -> Vec<RerankerModelInfo> {
             description: String::from("reranker model for English and Chinese"),
             model_code: String::from("BAAI/bge-reranker-base"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
+        },
+        RerankerModelInfo {
+            model: RerankerModel::BGERerankerV2M3,
+            description: String::from("reranker model for multilingual"),
+            model_code: String::from("rozgo/bge-reranker-v2-m3"),
+            model_file: String::from("model.onnx"),
+            additional_files: vec![String::from("model.onnx.data")],
         },
         RerankerModelInfo {
             model: RerankerModel::JINARerankerV1TurboEn,
             description: String::from("reranker model for English"),
             model_code: String::from("jinaai/jina-reranker-v1-turbo-en"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
         RerankerModelInfo {
             model: RerankerModel::JINARerankerV2BaseMultiligual,
             description: String::from("reranker model for multilingual"),
             model_code: String::from("jinaai/jina-reranker-v2-base-multilingual"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec![],
         },
     ];
     reranker_model_list
@@ -41,6 +53,7 @@ pub struct RerankerModelInfo {
     pub description: String,
     pub model_code: String,
     pub model_file: String,
+    pub additional_files: Vec<String>,
 }
 
 impl Display for RerankerModel {

--- a/src/reranking/init.rs
+++ b/src/reranking/init.rs
@@ -108,6 +108,18 @@ pub enum OnnxSource {
     File(PathBuf),
 }
 
+impl From<Vec<u8>> for OnnxSource {
+    fn from(bytes: Vec<u8>) -> Self {
+        OnnxSource::Memory(bytes)
+    }
+}
+
+impl From<PathBuf> for OnnxSource {
+    fn from(path: PathBuf) -> Self {
+        OnnxSource::File(path)
+    }
+}
+
 /// Struct for "bring your own" reranking models
 ///
 /// The onnx_file and tokenizer_files are expecting the files' bytes
@@ -119,9 +131,9 @@ pub struct UserDefinedRerankingModel {
 }
 
 impl UserDefinedRerankingModel {
-    pub fn new(onnx_source: OnnxSource, tokenizer_files: TokenizerFiles) -> Self {
+    pub fn new(onnx_source: impl Into<OnnxSource>, tokenizer_files: TokenizerFiles) -> Self {
         Self {
-            onnx_source,
+            onnx_source: onnx_source.into(),
             tokenizer_files,
         }
     }

--- a/src/reranking/init.rs
+++ b/src/reranking/init.rs
@@ -99,20 +99,29 @@ impl From<RerankInitOptions> for RerankInitOptionsUserDefined {
     }
 }
 
+/// Enum for the source of the onnx file
+///
+/// User-defined models can either be in memory or on disk
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OnnxSource {
+    Memory(Vec<u8>),
+    File(PathBuf),
+}
+
 /// Struct for "bring your own" reranking models
 ///
 /// The onnx_file and tokenizer_files are expecting the files' bytes
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UserDefinedRerankingModel {
-    pub onnx_file: Vec<u8>,
+    pub onnx_source: OnnxSource,
     pub tokenizer_files: TokenizerFiles,
 }
 
 impl UserDefinedRerankingModel {
-    pub fn new(onnx_file: Vec<u8>, tokenizer_files: TokenizerFiles) -> Self {
+    pub fn new(onnx_source: OnnxSource, tokenizer_files: TokenizerFiles) -> Self {
         Self {
-            onnx_file,
+            onnx_source,
             tokenizer_files,
         }
     }

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -421,8 +421,6 @@ fn test_user_defined_reranking_model() {
     )
     .expect("Could not read onnx file");
 
-    let onnx_source = OnnxSource::Memory(onnx_file);
-
     // Load the tokenizer files
     let tokenizer_files = TokenizerFiles {
         tokenizer_file: read_file_to_bytes(&model_files_dir.join("tokenizer.json"))
@@ -437,7 +435,7 @@ fn test_user_defined_reranking_model() {
             .expect("Could not read tokenizer_config.json"),
     };
     // Create a UserDefinedEmbeddingModel
-    let user_defined_model = UserDefinedRerankingModel::new(onnx_source, tokenizer_files);
+    let user_defined_model = UserDefinedRerankingModel::new(onnx_file, tokenizer_files);
 
     // Try creating a TextEmbedding instance from the user-defined model
     let user_defined_reranker = TextRerank::try_new_from_user_defined(

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -8,7 +8,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use fastembed::{
     read_file_to_bytes, Embedding, EmbeddingModel, ImageEmbedding, ImageInitOptions, InitOptions,
-    InitOptionsUserDefined, Pooling, QuantizationMode, RerankInitOptions,
+    InitOptionsUserDefined, OnnxSource, Pooling, QuantizationMode, RerankInitOptions,
     RerankInitOptionsUserDefined, RerankerModel, SparseInitOptions, SparseTextEmbedding,
     TextEmbedding, TextRerank, TokenizerFiles, UserDefinedEmbeddingModel,
     UserDefinedRerankingModel, DEFAULT_CACHE_DIR,
@@ -284,6 +284,8 @@ fn test_rerank() {
         .par_iter()
         .for_each(|supported_model| {
 
+            println!("supported_model: {:?}", supported_model);
+
         let result = TextRerank::try_new(RerankInitOptions::new(supported_model.model.clone()))
         .unwrap();
 
@@ -300,12 +302,76 @@ fn test_rerank() {
             .unwrap();
 
         assert_eq!(results.len(), documents.len(), "rerank model {:?} failed", supported_model);
-        assert_eq!(results[0].document.as_ref().unwrap(), "panda is an animal");
-        assert_eq!(results[1].document.as_ref().unwrap(), "The giant panda, sometimes called a panda bear or simply panda, is a bear species endemic to China.");
+
+        let option_a = "panda is an animal";
+        let option_b = "The giant panda, sometimes called a panda bear or simply panda, is a bear species endemic to China.";
+
+        assert!(
+            results[0].document.as_ref().unwrap() == option_a ||
+            results[0].document.as_ref().unwrap() == option_b
+        );
+        assert!(
+            results[1].document.as_ref().unwrap() == option_a ||
+            results[1].document.as_ref().unwrap() == option_b
+        );
+        assert_ne!(results[0].document, results[1].document, "The top two results should be different");
 
         // Clear the model cache to avoid running out of space on GitHub Actions.
         clean_cache(supported_model.model_code.clone())
     });
+}
+
+#[test]
+fn test_user_defined_reranking_large_model() {
+    // Setup model to download from Hugging Face
+    let cache = hf_hub::Cache::new(std::path::PathBuf::from(fastembed::DEFAULT_CACHE_DIR));
+    let api = hf_hub::api::sync::ApiBuilder::from_cache(cache)
+        .with_progress(true)
+        .build()
+        .expect("Failed to build API from cache");
+    let model_repo = api.model("rozgo/bge-reranker-v2-m3".to_string());
+
+    // Download the onnx model file
+    let onnx_file = model_repo.download("model.onnx").unwrap();
+    // Onnx model exceeds the limit of 2GB for a file, so we need to download the data file separately
+    let _onnx_data_file = model_repo.get("model.onnx.data").unwrap();
+
+    // OnnxSource::File is used to load the onnx file using onnx session builder commit_from_file
+    let onnx_source = OnnxSource::File(onnx_file);
+
+    // Load the tokenizer files
+    let tokenizer_files: TokenizerFiles = TokenizerFiles {
+        tokenizer_file: read_file_to_bytes(&model_repo.get("tokenizer.json").unwrap()).unwrap(),
+        config_file: read_file_to_bytes(&model_repo.get("config.json").unwrap()).unwrap(),
+        special_tokens_map_file: read_file_to_bytes(
+            &model_repo.get("special_tokens_map.json").unwrap(),
+        )
+        .unwrap(),
+
+        tokenizer_config_file: read_file_to_bytes(
+            &model_repo.get("tokenizer_config.json").unwrap(),
+        )
+        .unwrap(),
+    };
+
+    let model = UserDefinedRerankingModel::new(onnx_source, tokenizer_files);
+
+    let user_defined_reranker =
+        TextRerank::try_new_from_user_defined(model, Default::default()).unwrap();
+
+    let documents = vec![
+        "Hello, World!",
+        "This is an example passage.",
+        "fastembed-rs is licensed under Apache-2.0",
+        "Some other short text here blah blah blah",
+    ];
+
+    let results = user_defined_reranker
+        .rerank("Ciao, Earth!", documents.clone(), false, None)
+        .unwrap();
+
+    assert_eq!(results.len(), documents.len());
+    assert_eq!(results.first().unwrap().index, 0);
 }
 
 #[test]
@@ -355,6 +421,8 @@ fn test_user_defined_reranking_model() {
     )
     .expect("Could not read onnx file");
 
+    let onnx_source = OnnxSource::Memory(onnx_file);
+
     // Load the tokenizer files
     let tokenizer_files = TokenizerFiles {
         tokenizer_file: read_file_to_bytes(&model_files_dir.join("tokenizer.json"))
@@ -369,7 +437,7 @@ fn test_user_defined_reranking_model() {
             .expect("Could not read tokenizer_config.json"),
     };
     // Create a UserDefinedEmbeddingModel
-    let user_defined_model = UserDefinedRerankingModel::new(onnx_file, tokenizer_files);
+    let user_defined_model = UserDefinedRerankingModel::new(onnx_source, tokenizer_files);
 
     // Try creating a TextEmbedding instance from the user-defined model
     let user_defined_reranker = TextRerank::try_new_from_user_defined(


### PR DESCRIPTION
This PR introduces support for the BGE Reranker V2 M3 model and enhances the flexibility of user-defined reranking models. Key changes include:

1. Added `BGERerankerV2M3` to the `RerankerModel` enum, supporting the "bge-reranker-v2-m3" model.

2. Introduced `OnnxSource` enum to allow loading ONNX models from either memory or file:
   - `OnnxSource::Memory(Vec<u8>)`
   - `OnnxSource::File(PathBuf)`

3. Updated `UserDefinedRerankingModel` to use `OnnxSource` instead of `Vec<u8>` for ONNX data.

4. Modified `TextRerank::try_new_from_user_defined()` to handle both memory and file-based ONNX sources.

5. Added support for additional files in `RerankerModelInfo` to accommodate models with multiple files (e.g., BGE Reranker V2 M3).

6. Updated the reranking test to be more flexible with result ordering, as different models may produce slightly different rankings.

7. Added a new test `test_user_defined_reranking_large_model()` to demonstrate loading and using the BGE Reranker V2 M3 model.
