### PR TITLE
Update ort to 2.0.0-rc.8 to fix build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,7 @@ anyhow = { version = "1" }
 hf-hub = { version = "0.3", default-features = false }
 image = "0.25.2"
 ndarray = { version = "0.16", default-features = false }
-ort = { version = "=2.0.0-rc.5", default-features = false, features = [
-    "ndarray",
-] }
+ort = { version = "=2.0.0-rc.8", default-features = false, features = ["ndarray"] }
 rayon = { version = "1.10", default-features = false }
 serde_json = { version = "1" }
 tokenizers = { version = "0.19", default-features = false, features = ["onig"] }


### PR DESCRIPTION
See static linking fixes here: https://github.com/pykeio/ort/releases