### PR TITLE
adds support for nomic-embed-vision-v1.5 image embeddings model

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The default model is Flag Embedding, which is top of the [MTEB](https://huggingf
 - [**sentence-transformers/paraphrase-MiniLM-L12-v2**](https://huggingface.co/sentence-transformers/paraphrase-MiniLM-L12-v2)
 - [**sentence-transformers/paraphrase-multilingual-mpnet-base-v2**](https://huggingface.co/sentence-transformers/paraphrase-multilingual-mpnet-base-v2)
 - [**nomic-ai/nomic-embed-text-v1**](https://huggingface.co/nomic-ai/nomic-embed-text-v1)
-- [**nomic-ai/nomic-embed-text-v1.5**](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5)
+- [**nomic-ai/nomic-embed-text-v1.5**](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5) - pairs with the image model nomic-embed-vision-v1.5 for image-to-text search
 - [**intfloat/multilingual-e5-small**](https://huggingface.co/intfloat/multilingual-e5-small)
 - [**intfloat/multilingual-e5-base**](https://huggingface.co/intfloat/multilingual-e5-base)
 - [**intfloat/multilingual-e5-large**](https://huggingface.co/intfloat/multilingual-e5-large)
@@ -59,6 +59,7 @@ The default model is Flag Embedding, which is top of the [MTEB](https://huggingf
 - [**Qdrant/resnet50-onnx**](https://huggingface.co/Qdrant/resnet50-onnx)
 - [**Qdrant/Unicom-ViT-B-16**](https://huggingface.co/Qdrant/Unicom-ViT-B-16)
 - [**Qdrant/Unicom-ViT-B-32**](https://huggingface.co/Qdrant/Unicom-ViT-B-32)
+- [**nomic-ai/nomic-embed-vision-v1.5**](https://huggingface.co/nomic-ai/nomic-embed-vision-v1.5)
 
 ### Reranking
 

--- a/src/models/image_embedding.rs
+++ b/src/models/image_embedding.rs
@@ -12,6 +12,8 @@ pub enum ImageEmbeddingModel {
     UnicomVitB16,
     /// Qdrant/Unicom-ViT-B-32
     UnicomVitB32,
+    /// nomic-ai/nomic-embed-vision-v1.5
+    NomicEmbedVisionV15,
 }
 
 pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
@@ -43,7 +45,14 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("Unicom Unicom-ViT-B-32 from open-metric-learning"),
             model_code: String::from("Qdrant/Unicom-ViT-B-32"),
             model_file: String::from("model.onnx"),
-        }
+        },
+        ModelInfo {
+            model: ImageEmbeddingModel::NomicEmbedVisionV15,
+            dim: 768,
+            description: String::from("Nomic NomicEmbedVisionV15"),
+            model_code: String::from("nomic-ai/nomic-embed-vision-v1.5"),
+            model_file: String::from("onnx/model.onnx"),
+        },
     ];
 
     // TODO: Use when out in stable

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -463,6 +463,7 @@ fn test_user_defined_reranking_model() {
 }
 
 #[test]
+#[ignore]
 fn test_image_embedding_model() {
     ImageEmbedding::list_supported_models()
         .par_iter()
@@ -484,6 +485,62 @@ fn test_image_embedding_model() {
             // Clear the model cache to avoid running out of space on GitHub Actions.
             clean_cache(supported_model.model_code.clone())
         });
+}
+
+#[test]
+fn test_nomic_embed_vision_v1_5() {
+    fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+        let dot_product = a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();
+        let norm_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        dot_product / (norm_a * norm_b)
+    }
+
+    fn cosine_similarity_matrix(
+        embeddings_a: &[Vec<f32>],
+        embeddings_b: &[Vec<f32>],
+    ) -> Vec<Vec<f32>> {
+        embeddings_a
+            .iter()
+            .map(|a| {
+                embeddings_b
+                    .iter()
+                    .map(|b| cosine_similarity(a, b))
+                    .collect()
+            })
+            .collect()
+    }
+
+    // Test the NomicEmbedVisionV15 model specifically because it outputs a 3D tensor with a different
+    // output key ('last_hidden_state') compared to other models. This test ensures our tensor extraction
+    // logic can handle both standard output keys and this model's specific naming convention.
+    let image_model = ImageEmbedding::try_new(ImageInitOptions::new(
+        fastembed::ImageEmbeddingModel::NomicEmbedVisionV15,
+    ))
+    .unwrap();
+
+    // tests/assets/image_0.png is a blue cat
+    // tests/assets/image_1.png is a red cat
+    let images = vec!["tests/assets/image_0.png", "tests/assets/image_1.png"];
+    let image_embeddings = image_model.embed(images.clone(), None).unwrap();
+    assert_eq!(image_embeddings.len(), images.len());
+
+    let text_model = TextEmbedding::try_new(InitOptions::new(
+        fastembed::EmbeddingModel::NomicEmbedTextV15,
+    ))
+    .unwrap();
+    let texts = vec!["green cat", "blue cat", "red cat", "yellow cat", "dog"];
+    let text_embeddings = text_model.embed(texts.clone(), None).unwrap();
+
+    // Generate similarity matrix
+    let similarity_matrix = cosine_similarity_matrix(&text_embeddings, &image_embeddings);
+    // Print the similarity matrix with text labels
+    for (i, row) in similarity_matrix.iter().enumerate() {
+        println!("{}: {:?}", texts[i], row);
+    }
+
+    assert_eq!(text_embeddings.len(), texts.len());
+    assert_eq!(text_embeddings[0].len(), 768);
 }
 
 fn clean_cache(model_code: String) {

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -463,7 +463,6 @@ fn test_user_defined_reranking_model() {
 }
 
 #[test]
-#[ignore]
 fn test_image_embedding_model() {
     ImageEmbedding::list_supported_models()
         .par_iter()
@@ -488,6 +487,7 @@ fn test_image_embedding_model() {
 }
 
 #[test]
+#[ignore]
 fn test_nomic_embed_vision_v1_5() {
     fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         let dot_product = a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();


### PR DESCRIPTION
nomic-embed-vision-v1.5 image embeddings that shares the same embedding space as nomic-embed-text-v1.5

Includes a test that outputs the similarity matrix between image and text. First column is blue cat, second is red cat:
```
green cat: [0.07165963, 0.067335285]
blue cat: [0.09806663, 0.055019084]
red cat: [0.06977239, 0.10732647]
yellow cat: [0.07075872, 0.071573]
dog: [0.035324473, 0.020524085]
```