### PR TITLE
feat: Add jina v3 support

### DIFF
--- a/src/models/image_embedding.rs
+++ b/src/models/image_embedding.rs
@@ -24,6 +24,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("CLIP vision encoder based on ViT-B/32"),
             model_code: String::from("Qdrant/clip-ViT-B-32-vision"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: ImageEmbeddingModel::Resnet50,
@@ -31,6 +32,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("ResNet-50 from `Deep Residual Learning for Image Recognition <https://arxiv.org/abs/1512.03385>`__."),
             model_code: String::from("Qdrant/resnet50-onnx"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: ImageEmbeddingModel::UnicomVitB16,
@@ -38,6 +40,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("Unicom Unicom-ViT-B-16 from open-metric-learning"),
             model_code: String::from("Qdrant/Unicom-ViT-B-16"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: ImageEmbeddingModel::UnicomVitB32,
@@ -45,6 +48,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("Unicom Unicom-ViT-B-32 from open-metric-learning"),
             model_code: String::from("Qdrant/Unicom-ViT-B-32"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: ImageEmbeddingModel::NomicEmbedVisionV15,
@@ -52,6 +56,7 @@ pub fn models_list() -> Vec<ModelInfo<ImageEmbeddingModel>> {
             description: String::from("Nomic NomicEmbedVisionV15"),
             model_code: String::from("nomic-ai/nomic-embed-vision-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
     ];
 

--- a/src/models/model_info.rs
+++ b/src/models/model_info.rs
@@ -6,4 +6,5 @@ pub struct ModelInfo<T> {
     pub description: String,
     pub model_code: String,
     pub model_file: String,
+    pub additional_files: Vec<String>,
 }

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -16,6 +16,7 @@ pub fn models_list() -> Vec<ModelInfo<SparseModel>> {
         description: String::from("Splade sparse vector model for commercial use, v1"),
         model_code: String::from("Qdrant/Splade_PP_en_v1"),
         model_file: String::from("model.onnx"),
+        additional_files: Vec::new(),
     }]
 }
 

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -238,7 +238,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large model of multilingual E5 Text Embeddings"),
             model_code: String::from("Qdrant/multilingual-e5-large-onnx"),
             model_file: String::from("model.onnx"),
-            additional_files: Vec::new(),
+            additional_files: vec!["model.onnx_data".to_string()],
         },
         ModelInfo {
             model: EmbeddingModel::MxbaiEmbedLargeV1,
@@ -286,7 +286,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-large-en-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
-            additional_files: vec!["model.onnx_data".to_string()],
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::ClipVitB32,
@@ -310,7 +310,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Jina embeddings v3"),
             model_code: String::from("jinaai/jina-embeddings-v3"),
             model_file: String::from("onnx/model.onnx"),
-            additional_files: vec!["onnx/model.onxx_data".to_string()],
+            additional_files: vec!["onnx/model.onnx_data".to_string()],
         },
     ];
 

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -80,6 +80,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Sentence Transformer model, MiniLM-L6-v2"),
             model_code: String::from("Qdrant/all-MiniLM-L6-v2-onnx"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::AllMiniLML6V2Q,
@@ -87,6 +88,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Sentence Transformer model, MiniLM-L6-v2"),
             model_code: String::from("Xenova/all-MiniLM-L6-v2"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::AllMiniLML12V2,
@@ -94,6 +96,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Sentence Transformer model, MiniLM-L12-v2"),
             model_code: String::from("Xenova/all-MiniLM-L12-v2"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::AllMiniLML12V2Q,
@@ -101,6 +104,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Sentence Transformer model, MiniLM-L12-v2"),
             model_code: String::from("Xenova/all-MiniLM-L12-v2"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGEBaseENV15,
@@ -108,6 +112,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the base English model"),
             model_code: String::from("Xenova/bge-base-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGEBaseENV15Q,
@@ -115,6 +120,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized v1.5 release of the large English model"),
             model_code: String::from("Qdrant/bge-base-en-v1.5-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGELargeENV15,
@@ -122,6 +128,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the large English model"),
             model_code: String::from("Xenova/bge-large-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGELargeENV15Q,
@@ -129,6 +136,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized v1.5 release of the large English model"),
             model_code: String::from("Qdrant/bge-large-en-v1.5-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGESmallENV15,
@@ -136,6 +144,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the fast and default English model"),
             model_code: String::from("Xenova/bge-small-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGESmallENV15Q,
@@ -145,6 +154,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             ),
             model_code: String::from("Qdrant/bge-small-en-v1.5-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::NomicEmbedTextV1,
@@ -152,6 +162,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("8192 context length english model"),
             model_code: String::from("nomic-ai/nomic-embed-text-v1"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::NomicEmbedTextV15,
@@ -159,6 +170,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the 8192 context length english model"),
             model_code: String::from("nomic-ai/nomic-embed-text-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::NomicEmbedTextV15Q,
@@ -168,6 +180,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             ),
             model_code: String::from("nomic-ai/nomic-embed-text-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::ParaphraseMLMiniLML12V2Q,
@@ -175,6 +188,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Multi-lingual model"),
             model_code: String::from("Qdrant/paraphrase-multilingual-MiniLM-L12-v2-onnx-Q"),
             model_file: String::from("model_optimized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::ParaphraseMLMiniLML12V2,
@@ -182,6 +196,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Multi-lingual model"),
             model_code: String::from("Xenova/paraphrase-multilingual-MiniLM-L12-v2"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::ParaphraseMLMpnetBaseV2,
@@ -191,6 +206,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             ),
             model_code: String::from("Xenova/paraphrase-multilingual-mpnet-base-v2"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::BGESmallZHV15,
@@ -198,6 +214,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("v1.5 release of the small Chinese model"),
             model_code: String::from("Xenova/bge-small-zh-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::MultilingualE5Small,
@@ -205,6 +222,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Small model of multilingual E5 Text Embeddings"),
             model_code: String::from("intfloat/multilingual-e5-small"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::MultilingualE5Base,
@@ -212,6 +230,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Base model of multilingual E5 Text Embeddings"),
             model_code: String::from("intfloat/multilingual-e5-base"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::MultilingualE5Large,
@@ -219,6 +238,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large model of multilingual E5 Text Embeddings"),
             model_code: String::from("Qdrant/multilingual-e5-large-onnx"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::MxbaiEmbedLargeV1,
@@ -226,6 +246,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large English embedding model from MixedBreed.ai"),
             model_code: String::from("mixedbread-ai/mxbai-embed-large-v1"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::MxbaiEmbedLargeV1Q,
@@ -233,6 +254,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large English embedding model from MixedBreed.ai"),
             model_code: String::from("mixedbread-ai/mxbai-embed-large-v1"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::GTEBaseENV15,
@@ -240,6 +262,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-base-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::GTEBaseENV15Q,
@@ -247,6 +270,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-base-en-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::GTELargeENV15,
@@ -254,6 +278,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-large-en-v1.5"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::GTELargeENV15Q,
@@ -261,6 +286,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Quantized Large multilingual embedding model from Alibaba"),
             model_code: String::from("Alibaba-NLP/gte-large-en-v1.5"),
             model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec!["model.onnx_data".to_string()],
         },
         ModelInfo {
             model: EmbeddingModel::ClipVitB32,
@@ -268,6 +294,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("CLIP text encoder based on ViT-B/32"),
             model_code: String::from("Qdrant/clip-ViT-B-32-text"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::JinaEmbeddingsV2BaseCode,
@@ -275,6 +302,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Jina embeddings v2 base code"),
             model_code: String::from("jinaai/jina-embeddings-v2-base-code"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
         },
         ModelInfo {
             model: EmbeddingModel::JinaEmbeddingsV3,
@@ -282,6 +310,7 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Jina embeddings v3"),
             model_code: String::from("jinaai/jina-embeddings-v3"),
             model_file: String::from("onnx/model.onnx"),
+            additional_files: vec!["onnx/model.onxx_data".to_string()],
         },
     ];
 

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -65,6 +65,10 @@ pub enum EmbeddingModel {
     GTELargeENV15Q,
     /// Qdrant/clip-ViT-B-32-text
     ClipVitB32,
+    /// jinaai/jina-embeddings-v2-base-code
+    JinaEmbeddingsV2BaseCode,
+    /// jinaai/jina-embeddings-v3
+    JinaEmbeddingsV3,
 }
 
 /// Centralized function to initialize the models map.
@@ -265,6 +269,20 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             model_code: String::from("Qdrant/clip-ViT-B-32-text"),
             model_file: String::from("model.onnx"),
         },
+        ModelInfo {
+            model: EmbeddingModel::JinaEmbeddingsV2BaseCode,
+            dim: 768,
+            description: String::from("Jina embeddings v2 base code"),
+            model_code: String::from("jinaai/jina-embeddings-v2-base-code"),
+            model_file: String::from("onnx/model.onnx"),
+        },
+        ModelInfo {
+            model: EmbeddingModel::JinaEmbeddingsV3,
+            dim: 1024,
+            description: String::from("Jina embeddings v3"),
+            model_code: String::from("jinaai/jina-embeddings-v3"),
+            model_file: String::from("onnx/model.onnx"),
+        },
     ];
 
     // TODO: Use when out in stable
@@ -338,6 +356,9 @@ impl EmbeddingModel {
             EmbeddingModel::GTELargeENV15Q => Some(Pooling::Cls),
 
             EmbeddingModel::ClipVitB32 => Some(Pooling::Mean),
+
+            EmbeddingModel::JinaEmbeddingsV2BaseCode => Some(Pooling::Mean),
+            EmbeddingModel::JinaEmbeddingsV3 => Some(Pooling::Mean),
         }
     }
 

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -285,7 +285,8 @@ impl TextEmbedding {
             // the fly. Might be interesting to add later. From their docs, you can also select no
             // task, so we just input 0 for now.
             if self.needs_task_id {
-                let task_id_array = Array::from_shape_vec((batch_size, 1), vec![0; batch_size])?;
+                let task_id_array =
+                    Array::from_shape_vec((batch_size, 1), vec![0_i64; batch_size])?;
                 session_inputs.push(("task_id".into(), Value::from_array(task_id_array)?.into()));
             }
 

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -66,12 +66,12 @@ impl TextEmbedding {
             .get(model_file_name)
             .context(format!("Failed to retrieve {}", model_file_name))?;
 
-        // TODO: If more models need .onnx_data, implement a better way to handle this
-        // Probably by adding `additional_files` field in the `ModelInfo` struct
-        if model_name == EmbeddingModel::MultilingualE5Large {
-            model_repo
-                .get("model.onnx_data")
-                .expect("Failed to retrieve model.onnx_data.");
+        if !model_info.additional_files.is_empty() {
+            for file in &model_info.additional_files {
+                model_repo
+                    .get(file)
+                    .context(format!("Failed to retrieve {}", file))?;
+            }
         }
 
         // prioritise loading pooling config if available, if not (thanks qdrant!), look for it in hardcoded

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -285,8 +285,10 @@ impl TextEmbedding {
             // the fly. Might be interesting to add later. From their docs, you can also select no
             // task, so we just input 0 for now.
             if self.needs_task_id {
-                let task_id_array =
-                    Array::from_shape_vec((batch_size, encoding_length), vec![0_i64; batch_size])?;
+                let task_id_array = Array::from_shape_vec(
+                    (batch_size, encoding_length),
+                    vec![0_i64; batch_size * encoding_length],
+                )?;
                 session_inputs.push(("task_id".into(), Value::from_array(task_id_array)?.into()));
             }
 

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -286,7 +286,7 @@ impl TextEmbedding {
             // task, so we just input 0 for now.
             if self.needs_task_id {
                 let task_id_array =
-                    Array::from_shape_vec((batch_size, 1), vec![0_i64; batch_size])?;
+                    Array::from_shape_vec((batch_size, encoding_length), vec![0_i64; batch_size])?;
                 session_inputs.push(("task_id".into(), Value::from_array(task_id_array)?.into()));
             }
 

--- a/src/text_embedding/init.rs
+++ b/src/text_embedding/init.rs
@@ -163,5 +163,6 @@ pub struct TextEmbedding {
     pub(crate) pooling: Option<Pooling>,
     pub(crate) session: Session,
     pub(crate) need_token_type_ids: bool,
+    pub(crate) needs_task_id: bool,
     pub(crate) quantization: QuantizationMode,
 }

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -62,6 +62,8 @@ fn verify_embeddings(model: &EmbeddingModel, embeddings: &[Embedding]) -> Result
         EmbeddingModel::ParaphraseMLMiniLML12V2Q => [-0.07749095, -0.058981877, -0.043487836, -0.18775631],
         EmbeddingModel::ParaphraseMLMpnetBaseV2 => [0.39132136, 0.49490625, 0.65497226, 0.34237382],
         EmbeddingModel::ClipVitB32 => [0.7057363, 1.3549932, 0.46823958, 0.52351093],
+        EmbeddingModel::JinaEmbeddingsV2BaseCode => [-0.31383067, -0.3758629, -0.24878195, -0.35373706],
+        EmbeddingModel::JinaEmbeddingsV3 => [-0.31383067, -0.3758629, -0.24878195, -0.35373706],
         _ => panic!("Model {model} not found. If you have just inserted this `EmbeddingModel` variant, please update the expected embeddings."),
     };
 
@@ -189,7 +191,9 @@ fn test_sparse_embeddings() {
             });
 
             // Clear the model cache to avoid running out of space on GitHub Actions.
-            clean_cache(supported_model.model_code.clone())
+            if std::env::var("CI").is_ok() {
+                clean_cache(supported_model.model_code.clone())
+            }
         });
 }
 


### PR DESCRIPTION
Adds support for jina v2 code and jina v3, both popular and well ranking models.

I'm struggling a bit with the tests on my mac, getting some varied result. Last time on linux that wasn't an issue. Even though the Jina tests seem to pass.

