### PR TITLE
Add modernbert-embed-large

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - [**sentence-transformers/all-MiniLM-L12-v2**](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2)
 - [**sentence-transformers/paraphrase-MiniLM-L12-v2**](https://huggingface.co/sentence-transformers/paraphrase-MiniLM-L12-v2)
 - [**sentence-transformers/paraphrase-multilingual-mpnet-base-v2**](https://huggingface.co/sentence-transformers/paraphrase-multilingual-mpnet-base-v2)
+- [**lightonai/ModernBERT-embed-large**](https://huggingface.co/lightonai/modernbert-embed-large)
 - [**nomic-ai/nomic-embed-text-v1**](https://huggingface.co/nomic-ai/nomic-embed-text-v1)
 - [**nomic-ai/nomic-embed-text-v1.5**](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5) - pairs with the `nomic-embed-vision-v1.5` image model for image-to-text search
 - [**intfloat/multilingual-e5-small**](https://huggingface.co/intfloat/multilingual-e5-small)

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -41,6 +41,8 @@ pub enum EmbeddingModel {
     ParaphraseMLMpnetBaseV2,
     /// BAAI/bge-small-zh-v1.5
     BGESmallZHV15,
+    /// lightonai/modernbert-embed-large
+    ModernBertEmbedLarge,
     /// intfloat/multilingual-e5-small
     MultilingualE5Small,
     /// intfloat/multilingual-e5-base
@@ -207,6 +209,14 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             dim: 512,
             description: String::from("v1.5 release of the small Chinese model"),
             model_code: String::from("Xenova/bge-small-zh-v1.5"),
+            model_file: String::from("onnx/model.onnx"),
+            additional_files: Vec::new(),
+        },
+        ModelInfo {
+            model: EmbeddingModel::ModernBertEmbedLarge,
+            dim: 1024,
+            description: String::from("Large model of ModernBert Text Embeddings"),
+            model_code: String::from("lightonai/modernbert-embed-large"),
             model_file: String::from("onnx/model.onnx"),
             additional_files: Vec::new(),
         },

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -180,6 +180,8 @@ impl TextEmbedding {
             EmbeddingModel::ParaphraseMLMiniLML12V2Q => Some(Pooling::Mean),
             EmbeddingModel::ParaphraseMLMpnetBaseV2 => Some(Pooling::Mean),
 
+            EmbeddingModel::ModernBertEmbedLarge => Some(Pooling::Mean),
+
             EmbeddingModel::MultilingualE5Base => Some(Pooling::Mean),
             EmbeddingModel::MultilingualE5Small => Some(Pooling::Mean),
             EmbeddingModel::MultilingualE5Large => Some(Pooling::Mean),


### PR DESCRIPTION
This adds [ModernBERT-embed-large](https://huggingface.co/lightonai/modernbert-embed-large) to the roster of available models.

ModernBERT is an encoder-only base model that was released at the end of last year. The model itself cannot be used for embeddings but a finetuned `-embed-*` version can be.