### PR TITLE
feat: create models from model_code string

### DIFF
--- a/src/models/image_embedding.rs
+++ b/src/models/image_embedding.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use super::model_info::ModelInfo;
 
@@ -77,5 +77,25 @@ impl Display for ImageEmbeddingModel {
             .find(|model| model.model == *self)
             .unwrap();
         write!(f, "{}", model_info.model_code)
+    }
+}
+
+impl FromStr for ImageEmbeddingModel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        models_list()
+            .into_iter()
+            .find(|m| m.model_code.eq_ignore_ascii_case(s))
+            .map(|m| m.model)
+            .ok_or_else(|| format!("Unknown embedding model: {s}"))
+    }
+}
+
+impl TryFrom<String> for ImageEmbeddingModel {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }

--- a/src/models/reranking.rs
+++ b/src/models/reranking.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use crate::RerankerModelInfo;
 
@@ -55,5 +55,25 @@ impl Display for RerankerModel {
             .find(|model| model.model == *self)
             .expect("Model not found in supported models list.");
         write!(f, "{}", model_info.model_code)
+    }
+}
+
+impl FromStr for RerankerModel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        reranker_model_list()
+            .into_iter()
+            .find(|m| m.model_code.eq_ignore_ascii_case(s))
+            .map(|m| m.model)
+            .ok_or_else(|| format!("Unknown reranker model: {s}"))
+    }
+}
+
+impl TryFrom<String> for RerankerModel {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use crate::ModelInfo;
 
@@ -26,5 +26,25 @@ impl Display for SparseModel {
             .find(|model| model.model == *self)
             .unwrap();
         write!(f, "{}", model_info.model_code)
+    }
+}
+
+impl FromStr for SparseModel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        models_list()
+            .into_iter()
+            .find(|m| m.model_code.eq_ignore_ascii_case(s))
+            .map(|m| m.model)
+            .ok_or_else(|| format!("Unknown sparse model: {s}"))
+    }
+}
+
+impl TryFrom<String> for SparseModel {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display, sync::OnceLock};
+use std::{collections::HashMap, convert::TryFrom, fmt::Display, str::FromStr, sync::OnceLock};
 
 use super::model_info::ModelInfo;
 
@@ -358,5 +358,25 @@ impl Display for EmbeddingModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let model_info = get_model_info(self).expect("Model not found.");
         write!(f, "{}", model_info.model_code)
+    }
+}
+
+impl FromStr for EmbeddingModel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        models_list()
+            .into_iter()
+            .find(|m| m.model_code.eq_ignore_ascii_case(s))
+            .map(|m| m.model)
+            .ok_or_else(|| format!("Unknown embedding model: {s}"))
+    }
+}
+
+impl TryFrom<String> for EmbeddingModel {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }


### PR DESCRIPTION
Some trait implementations to construct any model enum from a string containing the model code.