### PR TITLE
refactor!: Upated ort usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
-  ONNX_VERSION: v1.20.1
+  ONNX_VERSION: v1.22.0
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,11 @@ anyhow = { version = "1" }
 hf-hub = { version = "0.4.1", default-features = false, optional = true }
 image = "0.25.2"
 ndarray = { version = "0.16", default-features = false }
-ort = { version = "=2.0.0-rc.9", default-features = false, features = [
-  "ndarray",
+ort = { version = "=2.0.0-rc.10", default-features = false, features = [
+  "ndarray", "std"
 ] }
-rayon = { version = "1.10", default-features = false }
 serde_json = { version = "1" }
-tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
-ort-sys = { version = "=2.0.0-rc.9", default-features = false }
+tokenizers = { version = "0.21.2", default-features = false, features = ["onig"] }
 
 [features]
 default = ["ort-download-binaries", "hf-hub-native-tls"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 - Supports synchronous usage. No dependency on Tokio.
 - Uses [@pykeio/ort](https://github.com/pykeio/ort) for performant ONNX inference.
 - Uses [@huggingface/tokenizers](https://github.com/huggingface/tokenizers) for fast encodings.
-- Supports batch embeddings generation with parallelism using [@rayon-rs/rayon](https://github.com/rayon-rs/rayon).
 
 ## 🔍 Not looking for Rust?
 
@@ -85,10 +84,10 @@ fastembed = "4"
 use fastembed::{TextEmbedding, InitOptions, EmbeddingModel};
 
 // With default InitOptions
-let model = TextEmbedding::try_new(Default::default())?;
+let mut model = TextEmbedding::try_new(Default::default())?;
 
 // With custom InitOptions
-let model = TextEmbedding::try_new(
+let mut model = TextEmbedding::try_new(
     InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true),
 )?;
 
@@ -114,10 +113,10 @@ let documents = vec![
 use fastembed::{ImageEmbedding, ImageInitOptions, ImageEmbeddingModel};
 
 // With default InitOptions
-let model = ImageEmbedding::try_new(Default::default())?;
+let mut model = ImageEmbedding::try_new(Default::default())?;
 
 // With custom InitOptions
-let model = ImageEmbedding::try_new(
+let mut model = ImageEmbedding::try_new(
     ImageInitOptions::new(ImageEmbeddingModel::ClipVitB32).with_show_download_progress(true),
 )?;
 
@@ -135,7 +134,7 @@ println!("Embedding dimension: {}", embeddings[0].len()); // -> Embedding dimens
 ```rust
 use fastembed::{TextRerank, RerankInitOptions, RerankerModel};
 
-let model = TextRerank::try_new(
+let mut model = TextRerank::try_new(
     RerankInitOptions::new(RerankerModel::BGERerankerBase).with_show_download_progress(true),
 )?;
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 
 ## 🚀 Installation
 
-Run the following command in your project directory:
+Run the following in your project directory:
 
 ```bash
 cargo add fastembed

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ fastembed = "4"
 ```rust
 use fastembed::{TextEmbedding, InitOptions, EmbeddingModel};
 
-// With default InitOptions
+// With default options
 let mut model = TextEmbedding::try_new(Default::default())?;
 
-// With custom InitOptions
+// With custom options
 let mut model = TextEmbedding::try_new(
     InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true),
 )?;
@@ -104,7 +104,30 @@ let documents = vec![
 
  println!("Embeddings length: {}", embeddings.len()); // -> Embeddings length: 4
  println!("Embedding dimension: {}", embeddings[0].len()); // -> Embedding dimension: 384
+```
 
+### Sparse Text Embeddings
+
+```rust
+use fastembed::{SparseEmbedding, SparseInitOptions, SparseModel, SparseTextEmbedding};
+
+// With default options
+let mut model = SparseTextEmbedding::try_new(Default::default())?;
+
+// With custom options
+let mut model = SparseTextEmbedding::try_new(
+    SparseInitOptions::new(SparseModel::SPLADEPPV1).with_show_download_progress(true),
+)?;
+
+let documents = vec![
+    "passage: Hello, World!",
+    "query: Hello, World!",
+    "passage: This is an example passage.",
+    "fastembed-rs is licensed under Apache  2.0"
+    ];
+
+// Generate embeddings with the default batch size, 256
+let embeddings: Vec<SparseEmbedding> = model.embed(documents, None)?;
 ```
 
 ### Image Embeddings
@@ -112,10 +135,10 @@ let documents = vec![
 ```rust
 use fastembed::{ImageEmbedding, ImageInitOptions, ImageEmbeddingModel};
 
-// With default InitOptions
+// With default options
 let mut model = ImageEmbedding::try_new(Default::default())?;
 
-// With custom InitOptions
+// With custom options
 let mut model = ImageEmbedding::try_new(
     ImageInitOptions::new(ImageEmbeddingModel::ClipVitB32).with_show_download_progress(true),
 )?;
@@ -134,6 +157,10 @@ println!("Embedding dimension: {}", embeddings[0].len()); // -> Embedding dimens
 ```rust
 use fastembed::{TextRerank, RerankInitOptions, RerankerModel};
 
+// With default options
+let mut model = TextRerank::try_new(Default::default())?;
+
+// With custom options
 let mut model = TextRerank::try_new(
     RerankInitOptions::new(RerankerModel::BGERerankerBase).with_show_download_progress(true),
 )?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 #[cfg(feature = "hf-hub")]
 use hf_hub::api::sync::{ApiBuilder, ApiRepo};
-use std::io::Read;
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 use tokenizers::{AddedToken, PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 
 const DEFAULT_CACHE_DIR: &str = ".fastembed_cache";
@@ -36,11 +35,11 @@ pub struct TokenizerFiles {
 #[cfg(feature = "hf-hub")]
 pub fn load_tokenizer_hf_hub(model_repo: ApiRepo, max_length: usize) -> Result<Tokenizer> {
     let tokenizer_files: TokenizerFiles = TokenizerFiles {
-        tokenizer_file: read_file_to_bytes(&model_repo.get("tokenizer.json")?)?,
-        config_file: read_file_to_bytes(&model_repo.get("config.json")?)?,
-        special_tokens_map_file: read_file_to_bytes(&model_repo.get("special_tokens_map.json")?)?,
+        tokenizer_file: std::fs::read(model_repo.get("tokenizer.json")?)?,
+        config_file: std::fs::read(&model_repo.get("config.json")?)?,
+        special_tokens_map_file: std::fs::read(&model_repo.get("special_tokens_map.json")?)?,
 
-        tokenizer_config_file: read_file_to_bytes(&model_repo.get("tokenizer_config.json")?)?,
+        tokenizer_config_file: std::fs::read(&model_repo.get("tokenizer_config.json")?)?,
     };
 
     load_tokenizer(tokenizer_files, max_length)
@@ -138,18 +137,6 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
 
     // We add the super-small epsilon to avoid dividing by zero
     v.iter().map(|&val| val / (norm + epsilon)).collect()
-}
-
-/// Public function to read a file to bytes.
-/// To be used when loading local model files.
-///
-/// Could be used to read the onnx file from a local cache in order to constitute a UserDefinedEmbeddingModel.
-pub fn read_file_to_bytes(file: &PathBuf) -> Result<Vec<u8>> {
-    let mut file = File::open(file)?;
-    let file_size = file.metadata()?.len() as usize;
-    let mut buffer = Vec::with_capacity(file_size);
-    file.read_to_end(&mut buffer)?;
-    Ok(buffer)
 }
 
 /// Pulls a model repo from HuggingFace..

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,7 @@ mod text_embedding;
 
 pub use ort::execution_providers::ExecutionProviderDispatch;
 
-pub use crate::common::{
-    get_cache_dir, read_file_to_bytes, Embedding, Error, SparseEmbedding, TokenizerFiles,
-};
+pub use crate::common::{get_cache_dir, Embedding, Error, SparseEmbedding, TokenizerFiles};
 pub use crate::models::{
     model_info::ModelInfo, model_info::RerankerModelInfo, quantization::QuantizationMode,
 };

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -161,11 +161,6 @@ create_embeddings_test!(
     batch_size: None,
 );
 
-create_embeddings_test!(
-    name: test_with_batch_size,
-    batch_size: Some(70),
-);
-
 #[test]
 fn test_sparse_embeddings() {
     SparseTextEmbedding::list_supported_models()

--- a/tests/embeddings.rs
+++ b/tests/embeddings.rs
@@ -4,14 +4,13 @@ use std::fs;
 use std::path::Path;
 
 use hf_hub::Repo;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use fastembed::{
-    get_cache_dir, read_file_to_bytes, Embedding, EmbeddingModel, ImageEmbedding,
-    ImageEmbeddingModel, ImageInitOptions, InitOptions, InitOptionsUserDefined, ModelInfo,
-    OnnxSource, Pooling, QuantizationMode, RerankInitOptions, RerankInitOptionsUserDefined,
-    RerankerModel, RerankerModelInfo, SparseInitOptions, SparseTextEmbedding, TextEmbedding,
-    TextRerank, TokenizerFiles, UserDefinedEmbeddingModel, UserDefinedRerankingModel,
+    get_cache_dir, Embedding, EmbeddingModel, ImageEmbedding, ImageEmbeddingModel,
+    ImageInitOptions, InitOptions, InitOptionsUserDefined, ModelInfo, OnnxSource, Pooling,
+    QuantizationMode, RerankInitOptions, RerankInitOptionsUserDefined, RerankerModel,
+    RerankerModelInfo, SparseInitOptions, SparseTextEmbedding, TextEmbedding, TextRerank,
+    TokenizerFiles, UserDefinedEmbeddingModel, UserDefinedRerankingModel,
 };
 
 /// A small epsilon value for floating point comparisons.
@@ -104,9 +103,9 @@ macro_rules! create_embeddings_test {
         #[test]
         fn $name() {
             TextEmbedding::list_supported_models()
-                .par_iter()
+                .iter()
                 .for_each(|supported_model| {
-                    let model: TextEmbedding = TextEmbedding::try_new(InitOptions::new(supported_model.model.clone()))
+                    let mut model: TextEmbedding = TextEmbedding::try_new(InitOptions::new(supported_model.model.clone()))
                     .unwrap();
 
                     let documents = vec![
@@ -170,9 +169,9 @@ create_embeddings_test!(
 #[test]
 fn test_sparse_embeddings() {
     SparseTextEmbedding::list_supported_models()
-        .par_iter()
+        .iter()
         .for_each(|supported_model| {
-            let model: SparseTextEmbedding =
+            let mut model: SparseTextEmbedding =
                 SparseTextEmbedding::try_new(SparseInitOptions::new(supported_model.model.clone()))
                     .unwrap();
 
@@ -224,8 +223,8 @@ fn test_user_defined_embedding_model() {
         .path();
 
     // Find the onnx file - it will be any file ending with .onnx
-    let onnx_file = read_file_to_bytes(
-        &model_files_dir
+    let onnx_file = std::fs::read(
+        model_files_dir
             .read_dir()
             .unwrap()
             .find(|entry| {
@@ -247,15 +246,13 @@ fn test_user_defined_embedding_model() {
 
     // Load the tokenizer files
     let tokenizer_files = TokenizerFiles {
-        tokenizer_file: read_file_to_bytes(&model_files_dir.join("tokenizer.json"))
+        tokenizer_file: std::fs::read(model_files_dir.join("tokenizer.json"))
             .expect("Could not read tokenizer.json"),
-        config_file: read_file_to_bytes(&model_files_dir.join("config.json"))
+        config_file: std::fs::read(model_files_dir.join("config.json"))
             .expect("Could not read config.json"),
-        special_tokens_map_file: read_file_to_bytes(
-            &model_files_dir.join("special_tokens_map.json"),
-        )
-        .expect("Could not read special_tokens_map.json"),
-        tokenizer_config_file: read_file_to_bytes(&model_files_dir.join("tokenizer_config.json"))
+        special_tokens_map_file: std::fs::read(model_files_dir.join("special_tokens_map.json"))
+            .expect("Could not read special_tokens_map.json"),
+        tokenizer_config_file: std::fs::read(model_files_dir.join("tokenizer_config.json"))
             .expect("Could not read tokenizer_config.json"),
     };
     // Create a UserDefinedEmbeddingModel
@@ -263,7 +260,7 @@ fn test_user_defined_embedding_model() {
         UserDefinedEmbeddingModel::new(onnx_file, tokenizer_files).with_pooling(Pooling::Mean);
 
     // Try creating a TextEmbedding instance from the user-defined model
-    let user_defined_text_embedding = TextEmbedding::try_new_from_user_defined(
+    let mut user_defined_text_embedding = TextEmbedding::try_new_from_user_defined(
         user_defined_model,
         InitOptionsUserDefined::default(),
     )
@@ -291,7 +288,7 @@ fn test_rerank() {
     let test_one_model = |supported_model: &RerankerModelInfo| {
         println!("supported_model: {:?}", supported_model);
 
-        let result =
+        let mut result =
             TextRerank::try_new(RerankInitOptions::new(supported_model.model.clone())).unwrap();
 
         let documents = vec![
@@ -333,7 +330,7 @@ fn test_rerank() {
         clean_cache(supported_model.model_code.clone())
     };
     TextRerank::list_supported_models()
-        .par_iter()
+        .iter()
         .for_each(test_one_model);
 }
 
@@ -358,22 +355,18 @@ fn test_user_defined_reranking_large_model() {
 
     // Load the tokenizer files
     let tokenizer_files: TokenizerFiles = TokenizerFiles {
-        tokenizer_file: read_file_to_bytes(&model_repo.get("tokenizer.json").unwrap()).unwrap(),
-        config_file: read_file_to_bytes(&model_repo.get("config.json").unwrap()).unwrap(),
-        special_tokens_map_file: read_file_to_bytes(
-            &model_repo.get("special_tokens_map.json").unwrap(),
-        )
-        .unwrap(),
+        tokenizer_file: std::fs::read(model_repo.get("tokenizer.json").unwrap()).unwrap(),
+        config_file: std::fs::read(model_repo.get("config.json").unwrap()).unwrap(),
+        special_tokens_map_file: std::fs::read(model_repo.get("special_tokens_map.json").unwrap())
+            .unwrap(),
 
-        tokenizer_config_file: read_file_to_bytes(
-            &model_repo.get("tokenizer_config.json").unwrap(),
-        )
-        .unwrap(),
+        tokenizer_config_file: std::fs::read(model_repo.get("tokenizer_config.json").unwrap())
+            .unwrap(),
     };
 
     let model = UserDefinedRerankingModel::new(onnx_source, tokenizer_files);
 
-    let user_defined_reranker =
+    let mut user_defined_reranker =
         TextRerank::try_new_from_user_defined(model, Default::default()).unwrap();
 
     let documents = vec![
@@ -416,8 +409,8 @@ fn test_user_defined_reranking_model() {
         .path();
 
     // Find the onnx file - it will be any file in ./onnx ending with .onnx
-    let onnx_file = read_file_to_bytes(
-        &model_files_dir
+    let onnx_file = std::fs::read(
+        model_files_dir
             .join("onnx")
             .read_dir()
             .unwrap()
@@ -440,22 +433,20 @@ fn test_user_defined_reranking_model() {
 
     // Load the tokenizer files
     let tokenizer_files = TokenizerFiles {
-        tokenizer_file: read_file_to_bytes(&model_files_dir.join("tokenizer.json"))
+        tokenizer_file: std::fs::read(model_files_dir.join("tokenizer.json"))
             .expect("Could not read tokenizer.json"),
-        config_file: read_file_to_bytes(&model_files_dir.join("config.json"))
+        config_file: std::fs::read(model_files_dir.join("config.json"))
             .expect("Could not read config.json"),
-        special_tokens_map_file: read_file_to_bytes(
-            &model_files_dir.join("special_tokens_map.json"),
-        )
-        .expect("Could not read special_tokens_map.json"),
-        tokenizer_config_file: read_file_to_bytes(&model_files_dir.join("tokenizer_config.json"))
+        special_tokens_map_file: std::fs::read(model_files_dir.join("special_tokens_map.json"))
+            .expect("Could not read special_tokens_map.json"),
+        tokenizer_config_file: std::fs::read(model_files_dir.join("tokenizer_config.json"))
             .expect("Could not read tokenizer_config.json"),
     };
     // Create a UserDefinedEmbeddingModel
     let user_defined_model = UserDefinedRerankingModel::new(onnx_file, tokenizer_files);
 
     // Try creating a TextEmbedding instance from the user-defined model
-    let user_defined_reranker = TextRerank::try_new_from_user_defined(
+    let mut user_defined_reranker = TextRerank::try_new_from_user_defined(
         user_defined_model,
         RerankInitOptionsUserDefined::default(),
     )
@@ -480,7 +471,7 @@ fn test_user_defined_reranking_model() {
 #[test]
 fn test_image_embedding_model() {
     let test_one_model = |supported_model: &ModelInfo<ImageEmbeddingModel>| {
-        let model: ImageEmbedding =
+        let mut model: ImageEmbedding =
             ImageEmbedding::try_new(ImageInitOptions::new(supported_model.model.clone())).unwrap();
 
         let images = vec!["tests/assets/image_0.png", "tests/assets/image_1.png"];
@@ -491,7 +482,7 @@ fn test_image_embedding_model() {
         assert_eq!(embeddings.len(), images.len());
     };
     ImageEmbedding::list_supported_models()
-        .par_iter()
+        .iter()
         .for_each(test_one_model);
 }
 
@@ -523,7 +514,7 @@ fn test_nomic_embed_vision_v1_5() {
     // Test the NomicEmbedVisionV15 model specifically because it outputs a 3D tensor with a different
     // output key ('last_hidden_state') compared to other models. This test ensures our tensor extraction
     // logic can handle both standard output keys and this model's specific naming convention.
-    let image_model = ImageEmbedding::try_new(ImageInitOptions::new(
+    let mut image_model = ImageEmbedding::try_new(ImageInitOptions::new(
         fastembed::ImageEmbeddingModel::NomicEmbedVisionV15,
     ))
     .unwrap();
@@ -534,7 +525,7 @@ fn test_nomic_embed_vision_v1_5() {
     let image_embeddings = image_model.embed(images.clone(), None).unwrap();
     assert_eq!(image_embeddings.len(), images.len());
 
-    let text_model = TextEmbedding::try_new(InitOptions::new(
+    let mut text_model = TextEmbedding::try_new(InitOptions::new(
         fastembed::EmbeddingModel::NomicEmbedTextV15,
     ))
     .unwrap();
@@ -566,7 +557,7 @@ fn get_sample_text() -> String {
 
 #[test]
 fn test_batch_size_does_not_change_output() {
-    let model = TextEmbedding::try_new(
+    let mut model = TextEmbedding::try_new(
         InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_max_length(384),
     )
     .expect("Create model successfully");
@@ -598,7 +589,7 @@ fn test_batch_size_does_not_change_output() {
 
 #[test]
 fn test_bgesmallen1point5_match_python_counterpart() {
-    let model = TextEmbedding::try_new(
+    let mut model = TextEmbedding::try_new(
         InitOptions::new(EmbeddingModel::BGESmallENV15).with_max_length(384),
     )
     .expect("Create model successfully");
@@ -637,7 +628,7 @@ fn test_bgesmallen1point5_match_python_counterpart() {
 
 #[test]
 fn test_allminilml6v2_match_python_counterpart() {
-    let model = TextEmbedding::try_new(
+    let mut model = TextEmbedding::try_new(
         InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_max_length(384),
     )
     .expect("Create model successfully");


### PR DESCRIPTION
# BREAKING

- Resolves #169 - Bump `ort` to `2.0.0-rc.10` with necessary refactors.
- Resolves #163 - Remove `read_file_to_bytes` with `std::fs::read`.
- Removed dependency on Rayon.
