### PR TITLE
Fix ordering of the model outputs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 ```
 # use fastembed::{TextEmbedding, InitOptions, EmbeddingModel};
 # fn embedding_demo() -> anyhow::Result<()> {
-# let model: TextEmbedding = TextEmbedding::try_new(Default::default())?;
+# let mut model: TextEmbedding = TextEmbedding::try_new(Default::default())?;
  let documents = vec![
     "passage: Hello, World!",
     "query: Hello, World!",

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -26,13 +26,14 @@ impl SingleBatchOutput {
         let ort_output: &ort::value::Value = precedence
             .key_precedence()
             .find_map(|key| match key {
+                // Only select the sole output if and only if there is exactly one.
                 OutputKey::OnlyOne => {
                     if self.outputs.len() == 1 {
                         self.outputs.first().map(|(_, v)| v)
                     } else {
                         None
                     }
-                },
+                }
                 OutputKey::ByOrder(idx) => self.outputs.iter().nth(*idx).map(|(_, v)| v),
                 OutputKey::ByName(name) => self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v),
             })

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -26,7 +26,6 @@ impl SingleBatchOutput {
         let ort_output: &ort::value::Value = precedence
             .key_precedence()
             .find_map(|key| match key {
-                // Only select the sole output if and only if there is exactly one.
                 OutputKey::OnlyOne => self.outputs.first().map(|(_, v)| v),
                 OutputKey::ByOrder(idx) => self.outputs.iter().nth(*idx).map(|(_, v)| v),
                 OutputKey::ByName(name) => self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v),

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -34,7 +34,7 @@ impl SingleBatchOutput {
                         None
                     }
                 }
-                OutputKey::ByOrder(idx) => self.outputs.iter().nth(*idx).map(|(_, v)| v),
+                OutputKey::ByOrder(idx) => self.outputs.get(*idx).map(|(_, v)| v),
                 OutputKey::ByName(name) => self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v),
             })
             .ok_or_else(|| {

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -10,7 +10,7 @@ use super::{OutputKey, OutputPrecedence};
 /// pooling etc. This struct should contain all the necessary information for the
 /// post-processing to be performed.
 pub struct SingleBatchOutput {
-    pub outputs: std::collections::BTreeMap<String, ort::value::Value>,
+    pub outputs: Vec<(String, ort::value::Value)>,
     pub attention_mask_array: Array2<i64>,
 }
 
@@ -27,20 +27,14 @@ impl SingleBatchOutput {
             .key_precedence()
             .find_map(|key| match key {
                 // Only select the sole output if and only if there is exactly one.
-                OutputKey::OnlyOne => {
-                    if self.outputs.len() == 1 {
-                        self.outputs.values().next()
-                    } else {
-                        None
-                    }
-                }
-                OutputKey::ByOrder(idx) => self.outputs.values().nth(*idx),
-                OutputKey::ByName(name) => self.outputs.get(*name),
+                OutputKey::OnlyOne => self.outputs.first().map(|(_, v)| v),
+                OutputKey::ByOrder(idx) => self.outputs.iter().nth(*idx).map(|(_, v)| v),
+                OutputKey::ByName(name) => self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v),
             })
             .ok_or_else(|| {
                 anyhow::Error::msg(format!(
                     "No suitable output found in the outputs. Available outputs: {:?}",
-                    self.outputs.keys().collect::<Vec<_>>()
+                    self.outputs.iter().map(|(k, _)| k).collect::<Vec<_>>()
                 ))
             })?;
 

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -26,7 +26,13 @@ impl SingleBatchOutput {
         let ort_output: &ort::value::Value = precedence
             .key_precedence()
             .find_map(|key| match key {
-                OutputKey::OnlyOne => self.outputs.first().map(|(_, v)| v),
+                OutputKey::OnlyOne => {
+                    if self.outputs.len() == 1 {
+                        self.outputs.first().map(|(_, v)| v)
+                    } else {
+                        None
+                    }
+                },
                 OutputKey::ByOrder(idx) => self.outputs.iter().nth(*idx).map(|(_, v)| v),
                 OutputKey::ByName(name) => self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v),
             })

--- a/src/text_embedding/output.rs
+++ b/src/text_embedding/output.rs
@@ -12,6 +12,7 @@ use super::TextEmbedding;
 /// The default output precedence for the TextEmbedding model.
 pub const OUTPUT_TYPE_PRECEDENCE: &[OutputKey] = &[
     OutputKey::OnlyOne,
+    OutputKey::ByName("text_embeds"),
     OutputKey::ByName("last_hidden_state"),
     OutputKey::ByName("sentence_embedding"),
     // Better not to expose this unless the user explicitly asks for it.


### PR DESCRIPTION
`BTreeMap` doesn't preserve the original order, but orders the entries by key.

To preserve the original order we need to use a simple Vec

Additionally, the change to `OnlyOne` doesn't appear to be correct, because the semantic output of CLIP-Vit32-B-Text is not matching the images if it checks for `len() == 1`