### PR TITLE
refactor: create a common struct & impl for embeddings

### DIFF
--- a/src/image_embedding/init.rs
+++ b/src/image_embedding/init.rs
@@ -1,58 +1,9 @@
-use std::path::{Path, PathBuf};
-
+use super::utils::Compose;
+use crate::{init::InitOptions, ImageEmbeddingModel};
 use ort::{execution_providers::ExecutionProviderDispatch, session::Session};
 
-use crate::{get_cache_dir, ImageEmbeddingModel};
-
-use super::{utils::Compose, DEFAULT_EMBEDDING_MODEL};
-
 /// Options for initializing the ImageEmbedding model
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct ImageInitOptions {
-    pub model_name: ImageEmbeddingModel,
-    pub execution_providers: Vec<ExecutionProviderDispatch>,
-    pub cache_dir: PathBuf,
-    pub show_download_progress: bool,
-}
-
-impl ImageInitOptions {
-    pub fn new(model_name: ImageEmbeddingModel) -> Self {
-        Self {
-            model_name,
-            ..Default::default()
-        }
-    }
-
-    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
-        self.cache_dir = cache_dir;
-        self
-    }
-
-    pub fn with_execution_providers(
-        mut self,
-        execution_providers: Vec<ExecutionProviderDispatch>,
-    ) -> Self {
-        self.execution_providers = execution_providers;
-        self
-    }
-
-    pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
-        self.show_download_progress = show_download_progress;
-        self
-    }
-}
-
-impl Default for ImageInitOptions {
-    fn default() -> Self {
-        Self {
-            model_name: DEFAULT_EMBEDDING_MODEL,
-            execution_providers: Default::default(),
-            cache_dir: Path::new(&get_cache_dir()).to_path_buf(),
-            show_download_progress: true,
-        }
-    }
-}
+pub type ImageInitOptions = InitOptions<ImageEmbeddingModel>;
 
 /// Options for initializing UserDefinedImageEmbeddingModel
 ///

--- a/src/image_embedding/mod.rs
+++ b/src/image_embedding/mod.rs
@@ -1,6 +1,4 @@
-use crate::models::image_embedding::ImageEmbeddingModel;
 const DEFAULT_BATCH_SIZE: usize = 256;
-const DEFAULT_EMBEDDING_MODEL: ImageEmbeddingModel = ImageEmbeddingModel::ClipVitB32;
 
 mod utils;
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,117 @@
+use crate::get_cache_dir;
+use ort::execution_providers::ExecutionProviderDispatch;
+use std::path::PathBuf;
+
+pub trait HasMaxLength {
+    const MAX_LENGTH: usize;
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct InitOptionsWithLength<M> {
+    pub model_name: M,
+    pub execution_providers: Vec<ExecutionProviderDispatch>,
+    pub cache_dir: PathBuf,
+    pub show_download_progress: bool,
+    pub max_length: usize,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct InitOptions<M> {
+    pub model_name: M,
+    pub execution_providers: Vec<ExecutionProviderDispatch>,
+    pub cache_dir: PathBuf,
+    pub show_download_progress: bool,
+}
+
+impl<M: Default + HasMaxLength> Default for InitOptionsWithLength<M> {
+    fn default() -> Self {
+        Self {
+            model_name: M::default(),
+            execution_providers: Default::default(),
+            cache_dir: get_cache_dir().into(),
+            show_download_progress: true,
+            max_length: M::MAX_LENGTH,
+        }
+    }
+}
+
+impl<M: Default> Default for InitOptions<M> {
+    fn default() -> Self {
+        Self {
+            model_name: M::default(),
+            execution_providers: Default::default(),
+            cache_dir: get_cache_dir().into(),
+            show_download_progress: true,
+        }
+    }
+}
+
+impl<M: Default + HasMaxLength> InitOptionsWithLength<M> {
+    /// Crea a new InitOptionsWithLength with the given model name
+    pub fn new(model_name: M) -> Self {
+        Self {
+            model_name,
+            ..Default::default()
+        }
+    }
+
+    /// Set the maximum maximum length
+    pub fn with_max_length(mut self, max_lenght: usize) -> Self {
+        self.max_length = max_lenght;
+        self
+    }
+
+    /// Set the cache directory for the model file
+    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
+        self.cache_dir = cache_dir;
+        self
+    }
+
+    /// Set the execution providers for the model
+    pub fn with_execution_providers(
+        mut self,
+        execution_providers: Vec<ExecutionProviderDispatch>,
+    ) -> Self {
+        self.execution_providers = execution_providers;
+        self
+    }
+
+    /// Set whether to show download progress
+    pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
+        self.show_download_progress = show_download_progress;
+        self
+    }
+}
+
+impl<M: Default> InitOptions<M> {
+    /// Crea a new InitOptionsWithLength with the given model name
+    pub fn new(model_name: M) -> Self {
+        Self {
+            model_name,
+            ..Default::default()
+        }
+    }
+
+    /// Set the cache directory for the model file
+    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
+        self.cache_dir = cache_dir;
+        self
+    }
+
+    /// Set the execution providers for the model
+    pub fn with_execution_providers(
+        mut self,
+        execution_providers: Vec<ExecutionProviderDispatch>,
+    ) -> Self {
+        self.execution_providers = execution_providers;
+        self
+    }
+
+    /// Set whether to show download progress
+    pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
+        self.show_download_progress = show_download_progress;
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 
 mod common;
 mod image_embedding;
+mod init;
 mod models;
 pub mod output;
 mod pooling;
@@ -74,7 +75,8 @@ pub use crate::pooling::Pooling;
 // For Text Embedding
 pub use crate::models::text_embedding::EmbeddingModel;
 pub use crate::text_embedding::{
-    InitOptions, InitOptionsUserDefined, TextEmbedding, UserDefinedEmbeddingModel,
+    InitOptionsUserDefined, TextEmbedding, TextInitOptions as InitOptions,
+    UserDefinedEmbeddingModel,
 };
 
 // For Sparse Text Embedding

--- a/src/models/image_embedding.rs
+++ b/src/models/image_embedding.rs
@@ -2,9 +2,10 @@ use std::{fmt::Display, str::FromStr};
 
 use super::model_info::ModelInfo;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum ImageEmbeddingModel {
     /// Qdrant/clip-ViT-B-32-vision
+    #[default]
     ClipVitB32,
     /// Qdrant/resnet50-onnx
     Resnet50,

--- a/src/models/reranking.rs
+++ b/src/models/reranking.rs
@@ -2,9 +2,10 @@ use std::{fmt::Display, str::FromStr};
 
 use crate::RerankerModelInfo;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum RerankerModel {
     /// BAAI/bge-reranker-base
+    #[default]
     BGERerankerBase,
     /// rozgo/bge-reranker-v2-m3
     BGERerankerV2M3,

--- a/src/models/sparse.rs
+++ b/src/models/sparse.rs
@@ -2,9 +2,10 @@ use std::{fmt::Display, str::FromStr};
 
 use crate::ModelInfo;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub enum SparseModel {
     /// prithivida/Splade_PP_en_v1
+    #[default]
     SPLADEPPV1,
 }
 

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -5,7 +5,7 @@ use super::model_info::ModelInfo;
 /// Lazy static list of all available models.
 static MODEL_MAP: OnceLock<HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>>> = OnceLock::new();
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EmbeddingModel {
     /// sentence-transformers/all-MiniLM-L6-v2
     AllMiniLML6V2,
@@ -24,6 +24,7 @@ pub enum EmbeddingModel {
     /// Quantized BAAI/bge-large-en-v1.5
     BGELargeENV15Q,
     /// BAAI/bge-small-en-v1.5 - Default
+    #[default]
     BGESmallENV15,
     /// Quantized BAAI/bge-small-en-v1.5
     BGESmallENV15Q,

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -22,7 +22,7 @@ impl SingleBatchOutput {
     pub fn select_output(
         &self,
         precedence: &impl OutputPrecedence,
-    ) -> anyhow::Result<ArrayView<f32, Dim<IxDynImpl>>> {
+    ) -> anyhow::Result<ArrayView<'_, f32, Dim<IxDynImpl>>> {
         let ort_output: &ort::value::Value = precedence
             .key_precedence()
             .find_map(|key| match key {
@@ -35,7 +35,9 @@ impl SingleBatchOutput {
                     }
                 }
                 OutputKey::ByOrder(idx) => self.outputs.get(*idx).map(|(_, v)| v),
-                OutputKey::ByName(name) => self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v),
+                OutputKey::ByName(name) => {
+                    self.outputs.iter().find(|(n, _)| n == name).map(|(_, v)| v)
+                }
             })
             .ok_or_else(|| {
                 anyhow::Error::msg(format!(

--- a/src/reranking/impl.rs
+++ b/src/reranking/impl.rs
@@ -54,9 +54,9 @@ impl TextRerank {
         use super::RerankInitOptions;
 
         let RerankInitOptions {
+            max_length,
             model_name,
             execution_providers,
-            max_length,
             cache_dir,
             show_download_progress,
         } = options;

--- a/src/reranking/init.rs
+++ b/src/reranking/init.rs
@@ -1,11 +1,11 @@
-use std::path::{Path, PathBuf};
-
+use super::DEFAULT_MAX_LENGTH;
+use crate::{
+    init::{HasMaxLength, InitOptionsWithLength},
+    RerankerModel, TokenizerFiles,
+};
 use ort::{execution_providers::ExecutionProviderDispatch, session::Session};
+use std::path::PathBuf;
 use tokenizers::Tokenizer;
-
-use crate::{common::get_cache_dir, RerankerModel, TokenizerFiles};
-
-use super::{DEFAULT_MAX_LENGTH, DEFAULT_RE_RANKER_MODEL};
 
 #[derive(Debug)]
 pub struct TextRerank {
@@ -14,60 +14,12 @@ pub struct TextRerank {
     pub(crate) need_token_type_ids: bool,
 }
 
-/// Options for initializing the reranking model
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct RerankInitOptions {
-    pub model_name: RerankerModel,
-    pub execution_providers: Vec<ExecutionProviderDispatch>,
-    pub max_length: usize,
-    pub cache_dir: PathBuf,
-    pub show_download_progress: bool,
+impl HasMaxLength for RerankerModel {
+    const MAX_LENGTH: usize = DEFAULT_MAX_LENGTH;
 }
 
-impl RerankInitOptions {
-    pub fn new(model_name: RerankerModel) -> Self {
-        Self {
-            model_name,
-            ..Default::default()
-        }
-    }
-
-    pub fn with_max_length(mut self, max_length: usize) -> Self {
-        self.max_length = max_length;
-        self
-    }
-
-    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
-        self.cache_dir = cache_dir;
-        self
-    }
-
-    pub fn with_execution_providers(
-        mut self,
-        execution_providers: Vec<ExecutionProviderDispatch>,
-    ) -> Self {
-        self.execution_providers = execution_providers;
-        self
-    }
-
-    pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
-        self.show_download_progress = show_download_progress;
-        self
-    }
-}
-
-impl Default for RerankInitOptions {
-    fn default() -> Self {
-        Self {
-            model_name: DEFAULT_RE_RANKER_MODEL,
-            execution_providers: Default::default(),
-            max_length: DEFAULT_MAX_LENGTH,
-            cache_dir: Path::new(&get_cache_dir()).to_path_buf(),
-            show_download_progress: true,
-        }
-    }
-}
+/// Options for initializing the reranking models
+pub type RerankInitOptions = InitOptionsWithLength<RerankerModel>;
 
 /// Options for initializing UserDefinedRerankerModel
 ///

--- a/src/reranking/mod.rs
+++ b/src/reranking/mod.rs
@@ -1,6 +1,3 @@
-use crate::RerankerModel;
-
-const DEFAULT_RE_RANKER_MODEL: RerankerModel = RerankerModel::BGERerankerBase;
 const DEFAULT_MAX_LENGTH: usize = 512;
 const DEFAULT_BATCH_SIZE: usize = 256;
 

--- a/src/sparse_text_embedding/impl.rs
+++ b/src/sparse_text_embedding/impl.rs
@@ -35,11 +35,11 @@ impl SparseTextEmbedding {
         use ort::{session::builder::GraphOptimizationLevel, session::Session};
 
         let SparseInitOptions {
-            model_name,
-            execution_providers,
             max_length,
+            model_name,
             cache_dir,
             show_download_progress,
+            execution_providers,
         } = options;
 
         let threads = available_parallelism()?.get();

--- a/src/sparse_text_embedding/init.rs
+++ b/src/sparse_text_embedding/init.rs
@@ -1,66 +1,20 @@
-use std::path::{Path, PathBuf};
-
-use ort::{execution_providers::ExecutionProviderDispatch, session::Session};
+use ort::session::Session;
 use tokenizers::Tokenizer;
 
-use crate::{common::get_cache_dir, models::sparse::SparseModel, TokenizerFiles};
+use crate::{
+    init::{HasMaxLength, InitOptionsWithLength},
+    models::sparse::SparseModel,
+    TokenizerFiles,
+};
 
-use super::{DEFAULT_EMBEDDING_MODEL, DEFAULT_MAX_LENGTH};
+use super::DEFAULT_MAX_LENGTH;
+
+impl HasMaxLength for SparseModel {
+    const MAX_LENGTH: usize = DEFAULT_MAX_LENGTH;
+}
 
 /// Options for initializing the SparseTextEmbedding model
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct SparseInitOptions {
-    pub model_name: SparseModel,
-    pub execution_providers: Vec<ExecutionProviderDispatch>,
-    pub max_length: usize,
-    pub cache_dir: PathBuf,
-    pub show_download_progress: bool,
-}
-
-impl SparseInitOptions {
-    pub fn new(model_name: SparseModel) -> Self {
-        Self {
-            model_name,
-            ..Default::default()
-        }
-    }
-
-    pub fn with_max_length(mut self, max_length: usize) -> Self {
-        self.max_length = max_length;
-        self
-    }
-
-    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
-        self.cache_dir = cache_dir;
-        self
-    }
-
-    pub fn with_execution_providers(
-        mut self,
-        execution_providers: Vec<ExecutionProviderDispatch>,
-    ) -> Self {
-        self.execution_providers = execution_providers;
-        self
-    }
-
-    pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
-        self.show_download_progress = show_download_progress;
-        self
-    }
-}
-
-impl Default for SparseInitOptions {
-    fn default() -> Self {
-        Self {
-            model_name: DEFAULT_EMBEDDING_MODEL,
-            execution_providers: Default::default(),
-            max_length: DEFAULT_MAX_LENGTH,
-            cache_dir: Path::new(&get_cache_dir()).to_path_buf(),
-            show_download_progress: true,
-        }
-    }
-}
+pub type SparseInitOptions = InitOptionsWithLength<SparseModel>;
 
 /// Struct for "bring your own" embedding models
 ///

--- a/src/sparse_text_embedding/mod.rs
+++ b/src/sparse_text_embedding/mod.rs
@@ -1,8 +1,5 @@
-use crate::models::sparse::SparseModel;
-
 const DEFAULT_BATCH_SIZE: usize = 256;
 const DEFAULT_MAX_LENGTH: usize = 512;
-const DEFAULT_EMBEDDING_MODEL: SparseModel = SparseModel::SPLADEPPV1;
 
 mod init;
 pub use init::*;

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -24,7 +24,7 @@ use std::thread::available_parallelism;
 use tokenizers::Tokenizer;
 
 #[cfg(feature = "hf-hub")]
-use super::InitOptions;
+use super::TextInitOptions;
 use super::{
     output, InitOptionsUserDefined, TextEmbedding, UserDefinedEmbeddingModel, DEFAULT_BATCH_SIZE,
 };
@@ -36,15 +36,14 @@ impl TextEmbedding {
     ///
     /// Uses the total number of CPUs available as the number of intra-threads
     #[cfg(feature = "hf-hub")]
-    pub fn try_new(options: InitOptions) -> Result<Self> {
-        let InitOptions {
+    pub fn try_new(options: TextInitOptions) -> Result<Self> {
+        let TextInitOptions {
+            max_length,
             model_name,
             execution_providers,
-            max_length,
             cache_dir,
             show_download_progress,
         } = options;
-
         let threads = available_parallelism()?.get();
 
         let model_repo = TextEmbedding::retrieve_model(

--- a/src/text_embedding/init.rs
+++ b/src/text_embedding/init.rs
@@ -2,73 +2,22 @@
 //!
 
 use crate::{
-    common::TokenizerFiles, get_cache_dir, pooling::Pooling, EmbeddingModel, QuantizationMode,
+    common::TokenizerFiles,
+    init::{HasMaxLength, InitOptionsWithLength},
+    pooling::Pooling,
+    EmbeddingModel, QuantizationMode,
 };
 use ort::{execution_providers::ExecutionProviderDispatch, session::Session};
-use std::path::{Path, PathBuf};
 use tokenizers::Tokenizer;
 
-use super::{DEFAULT_EMBEDDING_MODEL, DEFAULT_MAX_LENGTH};
+use super::DEFAULT_MAX_LENGTH;
+
+impl HasMaxLength for EmbeddingModel {
+    const MAX_LENGTH: usize = DEFAULT_MAX_LENGTH;
+}
 
 /// Options for initializing the TextEmbedding model
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct InitOptions {
-    pub model_name: EmbeddingModel,
-    pub execution_providers: Vec<ExecutionProviderDispatch>,
-    pub max_length: usize,
-    pub cache_dir: PathBuf,
-    pub show_download_progress: bool,
-}
-
-impl InitOptions {
-    /// Create a new InitOptions with the given model name
-    pub fn new(model_name: EmbeddingModel) -> Self {
-        Self {
-            model_name,
-            ..Default::default()
-        }
-    }
-
-    /// Set the maximum length of the input text
-    pub fn with_max_length(mut self, max_length: usize) -> Self {
-        self.max_length = max_length;
-        self
-    }
-
-    /// Set the cache directory for the model files
-    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
-        self.cache_dir = cache_dir;
-        self
-    }
-
-    /// Set the execution providers for the model
-    pub fn with_execution_providers(
-        mut self,
-        execution_providers: Vec<ExecutionProviderDispatch>,
-    ) -> Self {
-        self.execution_providers = execution_providers;
-        self
-    }
-
-    /// Set whether to show download progress
-    pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
-        self.show_download_progress = show_download_progress;
-        self
-    }
-}
-
-impl Default for InitOptions {
-    fn default() -> Self {
-        Self {
-            model_name: DEFAULT_EMBEDDING_MODEL,
-            execution_providers: Default::default(),
-            max_length: DEFAULT_MAX_LENGTH,
-            cache_dir: Path::new(&get_cache_dir()).to_path_buf(),
-            show_download_progress: true,
-        }
-    }
-}
+pub type TextInitOptions = InitOptionsWithLength<EmbeddingModel>;
 
 /// Options for initializing UserDefinedEmbeddingModel
 ///
@@ -113,8 +62,8 @@ impl Default for InitOptionsUserDefined {
 /// Convert InitOptions to InitOptionsUserDefined
 ///
 /// This is useful for when the user wants to use the same options for both the default and user-defined models
-impl From<InitOptions> for InitOptionsUserDefined {
-    fn from(options: InitOptions) -> Self {
+impl From<TextInitOptions> for InitOptionsUserDefined {
+    fn from(options: TextInitOptions) -> Self {
         InitOptionsUserDefined {
             execution_providers: options.execution_providers,
             max_length: options.max_length,
@@ -126,7 +75,6 @@ impl From<InitOptions> for InitOptionsUserDefined {
 ///
 /// The onnx_file and tokenizer_files are expecting the files' bytes
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct UserDefinedEmbeddingModel {
     pub onnx_file: Vec<u8>,
     pub tokenizer_files: TokenizerFiles,

--- a/src/text_embedding/mod.rs
+++ b/src/text_embedding/mod.rs
@@ -1,12 +1,9 @@
 //! Text embedding module, containing the main struct [TextEmbedding] and its
 //! initialization options.
 
-use crate::models::text_embedding::EmbeddingModel;
-
 // Constants.
 const DEFAULT_BATCH_SIZE: usize = 256;
 const DEFAULT_MAX_LENGTH: usize = 512;
-const DEFAULT_EMBEDDING_MODEL: EmbeddingModel = EmbeddingModel::BGESmallENV15;
 
 // Output precedence and transforming functions.
 pub mod output;


### PR DESCRIPTION
I'm currently working on a `deadpool_fastembed` library, and I realize it could be simplified with some common structs and implementations. Later on, I might implement `serde` support behind a feature flag. Let me know what you think of this direction! ;)