### PR TITLE
[WIP] feat: support Tarka embedding models

### DIFF
--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -72,6 +72,8 @@ pub enum EmbeddingModel {
     JinaEmbeddingsV2BaseCode,
     /// onnx-community/embeddinggemma-300m-ONNX
     EmbeddingGemma300M,
+    /// permutans/Tarka-Embedding-150M-V1-ONNX
+    TarkaEmbedding150MV1,
 }
 
 /// Centralized function to initialize the models map.
@@ -369,6 +371,15 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             model_code: String::from("onnx-community/embeddinggemma-300m-ONNX"),
             model_file: String::from("onnx/model.onnx"),
             additional_files: vec!["onnx/model.onnx_data".to_string()],
+            output_key: Some(crate::OutputKey::ByName("sentence_embedding")),
+        },
+        ModelInfo {
+            model: EmbeddingModel::TarkaEmbedding150MV1,
+            dim: 768,
+            description: String::from("Tarka-Embedding-150M-V1 distilled from EmbeddingGemma"),
+            model_code: String::from("permutans/Tarka-Embedding-150M-V1-ONNX"),
+            model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
             output_key: Some(crate::OutputKey::ByName("sentence_embedding")),
         },
     ];

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -194,6 +194,8 @@ impl TextEmbedding {
             EmbeddingModel::JinaEmbeddingsV2BaseCode => Some(Pooling::Mean),
 
             EmbeddingModel::EmbeddingGemma300M => Some(Pooling::Mean),
+
+            EmbeddingModel::TarkaEmbedding150MV1 => Some(Pooling::Mean),
         }
     }
 

--- a/tests/text-embeddings.rs
+++ b/tests/text-embeddings.rs
@@ -65,6 +65,7 @@ fn verify_embeddings(model: &EmbeddingModel, embeddings: &[Embedding]) -> Result
         EmbeddingModel::ClipVitB32 => [0.7057363, 1.3549932, 0.46823958, 0.52351093],
         EmbeddingModel::JinaEmbeddingsV2BaseCode => [-0.31383067, -0.3758629, -0.24878195, -0.35373706],
         EmbeddingModel::EmbeddingGemma300M => [0.22703816, 0.6947083, 0.07579082, 1.6958784],
+        EmbeddingModel::TarkaEmbedding150MV1 => [0.3165378, 0.8773776, 0.49043253, 1.7414812],
         _ => panic!("Model {model} not found. If you have just inserted this `EmbeddingModel` variant, please update the expected embeddings."),
     };
 


### PR DESCRIPTION
### Model 1a: Tarka-Embedding-150M-V1-ONNX

Smaller and faster than previous fastest per my benchmarking in [polars-fastembed](https://github.com/lmmx/polars-fastembed) (built on top of fastembed-rs).

The Tarka models are distilled from EmbeddingGemma (which ran slower than All-MiniLM-L6-v2 quants in my testing)

- Specifically 35% faster than previous best with Xenova/all-MiniLM-L6-v2 on GPU
  - 20s ⇒ 13s (~3.5ms per 1k tokens) 

Slower on CPU, ~3m33s (7x slower than All-MiniLM-L6-v2)

## Testing

(Converted to draft while I run further testing)

## Models

- [x] Tarka-Embedding-150M-V1-ONNX: [Model card](https://huggingface.co/permutans/Tarka-Embedding-150M-V1-ONNX), 595MB

## Issues

- https://github.com/huggingface/optimum/issues/2393
  - Unable to optimise with `-O2` or `-O3` flags, which I think causes CPU perf to be worse. GPU perf is great regardless