### PR TITLE
feat: qwen3-based zembed-1 impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [**Qwen/Qwen3-Embedding-4B**](https://huggingface.co/Qwen/Qwen3-Embedding-4B) - requires `qwen3` feature (candle backend)
 - [**Qwen/Qwen3-Embedding-8B**](https://huggingface.co/Qwen/Qwen3-Embedding-8B) - requires `qwen3` feature (candle backend)
 - [**Qwen/Qwen3-VL-Embedding-2B**](https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B) - requires `qwen3` feature (candle backend, multimodal via `Qwen3VLEmbedding`)
+- [**zeroentropy/zembed-1**](https://huggingface.co/zeroentropy/zembed-1) - requires `qwen3` feature (candle backend, via `ZembedTextEmbedding`)
 - [**snowflake/snowflake-arctic-embed-xs**](https://huggingface.co/snowflake/snowflake-arctic-embed-xs)
 - [**snowflake/snowflake-arctic-embed-s**](https://huggingface.co/snowflake/snowflake-arctic-embed-s)
 - [**snowflake/snowflake-arctic-embed-m**](https://huggingface.co/snowflake/snowflake-arctic-embed-m)
@@ -175,6 +176,26 @@ let text_embeddings = model.embed_texts(&["query: blue cat", "query: red cat"])?
 
 println!("Image embeddings: {}", image_embeddings.len());
 println!("Text embeddings: {}", text_embeddings.len());
+```
+
+For **zeroentropy/zembed-1**, use `ZembedTextEmbedding` which natively supports Matryoshka dimension truncation and optimal prompt formatting:
+
+```rust
+use candle_core::{DType, Device};
+use fastembed::ZembedTextEmbedding;
+
+let device = Device::Cpu;
+let model = ZembedTextEmbedding::from_hf(
+    "zeroentropy/zembed-1",
+    &device,
+    DType::F32,
+    2048,
+)?;
+
+// Shrink the embedding via Matryoshka (MRL) projection to any size (e.g., 2560, 1280, 640)
+// by passing the desired dimension to the `embed` method!
+let embeddings = model.embed(&["This natively runs in FastEmbed without ONNX!"], Some(1280))?;
+println!("Embedding dimension: {}", embeddings[0].len());
 ```
 
 ### Nomic Embed Text v2 MoE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub use crate::reranking::{
 // For Qwen3 (candle backend)
 #[cfg(feature = "qwen3")]
 pub use crate::models::qwen3::{
-    Config as Qwen3Config, Qwen3Model, Qwen3TextEmbedding, Qwen3VLEmbedding,
+    Config as Qwen3Config, Qwen3Model, Qwen3TextEmbedding, Qwen3VLEmbedding, ZembedTextEmbedding,
 };
 
 // For Nomic Embed Text v2 MoE (candle backend)

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -1176,7 +1176,13 @@ impl ZembedTextEmbedding {
 
         let encodings = self
             .tokenizer
-            .encode_batch(augmented_texts.iter().map(|s| s.as_str()).collect::<Vec<_>>(), true)
+            .encode_batch(
+                augmented_texts
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>(),
+                true,
+            )
             .map_err(|e| candle_core::Error::Msg(e.to_string()))?;
 
         let batch_size = encodings.len();
@@ -1203,7 +1209,7 @@ impl ZembedTextEmbedding {
         // Last token pooling
         let pooled = hidden.i((.., seq_len - 1))?;
 
-        // MRL projection/truncation 
+        // MRL projection/truncation
         let pooled = if let Some(d) = dim {
             pooled.narrow(1, 0, d)?
         } else {

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -1131,6 +1131,94 @@ impl Qwen3TextEmbedding {
     }
 }
 
+/// high-level embedding wrapper tailored for zeroentropy/zembed-1 which is based on qwen3.
+/// this wrapper handles the specific requirement of appending `<|im_end|>\n` to all texts
+/// and supports Matryoshka dimensional truncation before normalization
+pub struct ZembedTextEmbedding {
+    model: Qwen3Model,
+    tokenizer: tokenizers::Tokenizer,
+}
+
+impl ZembedTextEmbedding {
+    #[cfg(feature = "hf-hub")]
+    pub fn from_hf(
+        repo_id: &str,
+        device: &Device,
+        dtype: DType,
+        max_length: usize,
+    ) -> Result<Self> {
+        let base = Qwen3TextEmbedding::from_hf(repo_id, device, dtype, max_length)?;
+        Ok(Self {
+            model: base.model,
+            tokenizer: base.tokenizer,
+        })
+    }
+
+    pub fn config(&self) -> &Config {
+        self.model.config()
+    }
+
+    pub fn device(&self) -> &Device {
+        self.model.device()
+    }
+
+    /// Embed a batch of texts, appending `<|im_end|>\n` as required by zembed-1.
+    /// Supports dimensionality reduction (Matryoshka truncation) prior to L2 normalization.
+    pub fn embed<S: AsRef<str>>(&self, texts: &[S], dim: Option<usize>) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let augmented_texts: Vec<String> = texts
+            .iter()
+            .map(|t| format!("{}<|im_end|>\n", t.as_ref()))
+            .collect();
+
+        let encodings = self
+            .tokenizer
+            .encode_batch(augmented_texts.iter().map(|s| s.as_str()).collect::<Vec<_>>(), true)
+            .map_err(|e| candle_core::Error::Msg(e.to_string()))?;
+
+        let batch_size = encodings.len();
+        let seq_len = encodings[0].len();
+
+        let mut input_ids_vec: Vec<u32> = Vec::with_capacity(batch_size * seq_len);
+        let mut attention_mask_vec: Vec<f32> = Vec::with_capacity(batch_size * seq_len);
+
+        for enc in &encodings {
+            input_ids_vec.extend(enc.get_ids().iter().copied());
+            attention_mask_vec.extend(enc.get_attention_mask().iter().map(|&m| m as f32));
+        }
+
+        let device = self.model.device();
+        let input_ids = Tensor::from_vec(input_ids_vec, (batch_size, seq_len), device)?;
+        let attention_mask_2d =
+            Tensor::from_vec(attention_mask_vec, (batch_size, seq_len), device)?;
+
+        let attention_mask_4d = build_attention_mask_4d(&attention_mask_2d)?;
+
+        // Forward pass -> [B, T, H]
+        let hidden = self.model.forward(&input_ids, Some(&attention_mask_4d))?;
+
+        // Last token pooling
+        let pooled = hidden.i((.., seq_len - 1))?;
+
+        // MRL projection/truncation 
+        let pooled = if let Some(d) = dim {
+            pooled.narrow(1, 0, d)?
+        } else {
+            pooled
+        };
+
+        // L2 normalize
+        let normalized = l2_normalize(&pooled)?;
+
+        let normalized = normalized.to_dtype(DType::F32)?;
+        let data = normalized.to_vec2::<f32>()?;
+        Ok(data)
+    }
+}
+
 /// Multimodal embedding wrapper for Qwen3-VL embedding checkpoints.
 ///
 /// This supports text-only and image-only inputs. Image+text mixed inputs can be

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "qwen3")]
 
 use candle_core::{DType, Device};
-use fastembed::{Qwen3TextEmbedding, Qwen3VLEmbedding};
+use fastembed::{Qwen3TextEmbedding, Qwen3VLEmbedding, ZembedTextEmbedding};
 
 const REPO_06B: &str = "Qwen/Qwen3-Embedding-0.6B";
 const REPO_4B: &str = "Qwen/Qwen3-Embedding-4B";
@@ -201,4 +201,40 @@ fn qwen3_vl_2b_image_embed() {
         (image_dot - expected_dot_from_python).abs() < 1e-2,
         "image cosine mismatch: got {image_dot}, expected {expected_dot_from_python}"
     );
+}
+
+#[test]
+fn zembed1_embed() {
+    if std::env::var("RUN_ZEMBED").is_err() {
+        return;
+    }
+    
+    let device = Device::Cpu;
+    let model = ZembedTextEmbedding::from_hf("zeroentropy/zembed-1", &device, DType::F32, 2048).expect("load model");
+
+    let queries = ["What is the capital of China?", "Explain gravity"];
+    let documents = [
+        "Beijing is the capital of China.",
+        "Gravity is a force that attracts objects toward each other.",
+    ];
+
+    let all_texts: Vec<&str> = queries.iter().chain(documents.iter()).copied().collect();
+    
+    // Check default embedding (no projection)
+    let embeddings = model.embed(&all_texts, None).expect("embed");
+
+    assert_eq!(embeddings.len(), all_texts.len());
+    for emb in &embeddings {
+        assert_eq!(emb.len(), 2560);
+        let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "expected L2-normalized, got {norm}");
+    }
+
+    // Check with requested dimensional truncation
+    let truncated_embeddings = model.embed(&all_texts, Some(1280)).expect("embed truncated");
+    for emb in &truncated_embeddings {
+        assert_eq!(emb.len(), 1280);
+        let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "expected L2-normalized, got {norm}");
+    }
 }

--- a/tests/qwen3.rs
+++ b/tests/qwen3.rs
@@ -208,9 +208,10 @@ fn zembed1_embed() {
     if std::env::var("RUN_ZEMBED").is_err() {
         return;
     }
-    
+
     let device = Device::Cpu;
-    let model = ZembedTextEmbedding::from_hf("zeroentropy/zembed-1", &device, DType::F32, 2048).expect("load model");
+    let model = ZembedTextEmbedding::from_hf("zeroentropy/zembed-1", &device, DType::F32, 2048)
+        .expect("load model");
 
     let queries = ["What is the capital of China?", "Explain gravity"];
     let documents = [
@@ -219,7 +220,7 @@ fn zembed1_embed() {
     ];
 
     let all_texts: Vec<&str> = queries.iter().chain(documents.iter()).copied().collect();
-    
+
     // Check default embedding (no projection)
     let embeddings = model.embed(&all_texts, None).expect("embed");
 
@@ -227,14 +228,22 @@ fn zembed1_embed() {
     for emb in &embeddings {
         assert_eq!(emb.len(), 2560);
         let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
-        assert!((norm - 1.0).abs() < 1e-4, "expected L2-normalized, got {norm}");
+        assert!(
+            (norm - 1.0).abs() < 1e-4,
+            "expected L2-normalized, got {norm}"
+        );
     }
 
     // Check with requested dimensional truncation
-    let truncated_embeddings = model.embed(&all_texts, Some(1280)).expect("embed truncated");
+    let truncated_embeddings = model
+        .embed(&all_texts, Some(1280))
+        .expect("embed truncated");
     for emb in &truncated_embeddings {
         assert_eq!(emb.len(), 1280);
         let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
-        assert!((norm - 1.0).abs() < 1e-4, "expected L2-normalized, got {norm}");
+        assert!(
+            (norm - 1.0).abs() < 1e-4,
+            "expected L2-normalized, got {norm}"
+        );
     }
 }


### PR DESCRIPTION
cant find any onnx versions so added `ZembedTextEmbedding` along qwen3 as its the base model
havent tested personally, cpp linkers broken so workflow tests should catch any bugs i didnt in logic

Resolves #233