### PR TITLE
fix: Qwen3 F16 dtype mismatches in attention and l2_normalize

### DIFF
--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -148,7 +148,9 @@ fn build_attention_mask_4d(attention_mask_2d: &Tensor) -> Result<Tensor> {
 
 fn l2_normalize(xs: &Tensor) -> Result<Tensor> {
     let sum_sq = xs.sqr()?.sum_keepdim(1)?;
-    let eps_tensor = Tensor::new(&[1e-12f32], xs.device())?.broadcast_as(sum_sq.shape())?;
+    let eps_tensor = Tensor::new(&[1e-12f32], xs.device())?
+        .to_dtype(sum_sq.dtype())?
+        .broadcast_as(sum_sq.shape())?;
     let norm = sum_sq.add(&eps_tensor)?.sqrt()?;
     xs.broadcast_div(&norm)
 }
@@ -815,11 +817,11 @@ impl Qwen3Attention {
         let kt = k.transpose(2, 3)?; // [B,Nh,D,T]
         let mut attn = q.matmul(&kt)?; // [B,Nh,T,T]
 
-        let scale = scalar_f32(attn.device(), self.scaling)?;
+        let scale = scalar_f32(attn.device(), self.scaling)?.to_dtype(attn.dtype())?;
         attn = attn.broadcast_mul(&scale)?;
 
         if let Some(mask) = attention_mask {
-            attn = attn.broadcast_add(mask)?;
+            attn = attn.broadcast_add(&mask.to_dtype(attn.dtype())?)?;
         }
 
         // softmax over last dim


### PR DESCRIPTION
## Summary

- Three dtype-sensitive operations in `src/models/qwen3.rs` assume F32 but fail when the model runs in F16 (or any non-F32 dtype)
- Attention scale scalar (`scalar_f32`) broadcast_mul with F16 attention scores causes "dtype mismatch in mul, lhs: F16, rhs: F32"
- Attention mask from `build_attention_mask_4d` is always F32, broadcast_add with F16 attn fails similarly
- L2 normalize epsilon tensor is F32, broadcast_add with F16 sum_sq fails

Each fix casts the F32 tensor to match the model's dtype before the binary op.

## Test plan

- [x] Loaded Qwen3-VL-Embedding-2B in F16 on CPU — all three operations succeed where they previously errored
- [x] Text embedding produces correct 2048-dim vectors
- [x] Image embedding produces correct 2048-dim vectors
- [x] Cosine similarity between relevant text query and page image is positive and higher than irrelevant query

🤖 Generated with [Claude Code](https://claude.com/claude-code)