### PR TITLE
feat: register jina-embeddings-v5-text-nano-retrieval

### DIFF
--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -74,6 +74,14 @@ pub enum EmbeddingModel {
     JinaEmbeddingsV2BaseCode,
     /// jinaai/jina-embeddings-v2-base-en
     JinaEmbeddingsV2BaseEN,
+    /// jinaai/jina-embeddings-v5-text-nano-retrieval
+    ///
+    /// License: CC BY-NC 4.0 (non-commercial). Commercial use requires a
+    /// commercial license from Jina AI. The retrieval variant supports
+    /// asymmetric prompts via instruction prefixes
+    /// (`retrieval.query: ` / `retrieval.passage: `) and Matryoshka
+    /// truncation in {32, 64, 128, 256, 512, 768}.
+    JinaEmbeddingsV5TextNano,
     /// onnx-community/embeddinggemma-300m-ONNX
     EmbeddingGemma300M,
     /// snowflake/snowflake-arctic-embed-xs
@@ -406,6 +414,17 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             description: String::from("Jina embeddings v2 base English"),
             model_code: String::from("jinaai/jina-embeddings-v2-base-en"),
             model_file: String::from("model.onnx"),
+            additional_files: Vec::new(),
+            output_key: None,
+        },
+        ModelInfo {
+            model: EmbeddingModel::JinaEmbeddingsV5TextNano,
+            dim: 768,
+            description: String::from(
+                "Jina embeddings v5 text nano retrieval (CC BY-NC 4.0, non-commercial)",
+            ),
+            model_code: String::from("jinaai/jina-embeddings-v5-text-nano-retrieval"),
+            model_file: String::from("onnx/model.onnx"),
             additional_files: Vec::new(),
             output_key: None,
         },

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -248,6 +248,7 @@ impl TextEmbedding {
 
             EmbeddingModel::JinaEmbeddingsV2BaseCode => Some(Pooling::Mean),
             EmbeddingModel::JinaEmbeddingsV2BaseEN => Some(Pooling::Mean),
+            EmbeddingModel::JinaEmbeddingsV5TextNano => Some(Pooling::Mean),
 
             EmbeddingModel::EmbeddingGemma300M => Some(Pooling::Mean),
 


### PR DESCRIPTION
## Summary

Registers `jinaai/jina-embeddings-v5-text-nano-retrieval` as a built-in `EmbeddingModel` variant. Inference uses the existing ONNX runner — no architecture changes required.

Related upstream: qdrant/fastembed#607 (Python issue). No Anush008/fastembed-rs equivalent existed.

## What's added

| File | Change |
|------|--------|
| `src/models/text_embedding.rs` | New `EmbeddingModel::JinaEmbeddingsV5TextNano` variant with rustdoc covering license + Matryoshka dim list |
| `src/models/text_embedding.rs` | `ModelInfo` entry in `init_models_map()`: dim=768, model_code=`jinaai/jina-embeddings-v5-text-nano-retrieval`, model_file=`onnx/model.onnx` |
| `src/text_embedding/impl.rs` | `EmbeddingModel::JinaEmbeddingsV5TextNano => Some(Pooling::Mean)` in `get_default_pooling_method()` |

## Model

- **HF model:** `jinaai/jina-embeddings-v5-text-nano-retrieval`
- **Architecture:** EuroBERT-style encoder (standard ONNX export with `last_hidden_state`)
- **Output dim:** 768 (full); Matryoshka-truncatable to {32, 64, 128, 256, 512, 768}
- **Context:** 8K tokens
- **Pooling:** mean over `last_hidden_state` with attention-mask masking
- **License:** CC BY-NC 4.0 (non-commercial) — Jina AI sells commercial licenses separately

## What's NOT in this PR

- **Snapshot test entry** in `tests/text-embeddings.rs`. The existing `_ => panic!("...please update the expected embeddings.")` arm signals to CI / contributor that real expected sums must be captured by running the test once with `ORT_LIB_LOCATION` set. Snapshot capture requires ~50 MB ONNX Runtime + ~250 MB model download; happy to add the values in a follow-up commit if the maintainer prefers, or you can run the test once on CI infra and we update.
- **Asymmetric retrieval API** (`embed_query` / `with_query_prefix`). The retrieval variant supports `retrieval.query: ` / `retrieval.passage: ` prefixes in production but wiring that as a typed API is the same surface as closed PR #236 — out of scope here. Users may prepend prefixes manually for now.
- **`jina-embeddings-v5-text-small`** (Qwen3 decoder-based). Needs decoder ONNX plumbing (last-token pooling, position_ids/KV-cache injection) that fastembed-rs main lacks. PR #236 attempted this and was closed; not re-attempted in this PR.

## Verification

`cargo build` clean against current main:

```
$ cargo build
   Compiling fastembed v5.13.4
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 37.59s
```

Downstream consumer ([rtk-ai/icm](https://github.com/rtk-ai/icm)) ships its own ort+tokenizer integration for Jina v5 today as a workaround; this PR enables the simpler `TextEmbedding::try_new(InitOptions::new(EmbeddingModel::JinaEmbeddingsV5TextNano))` path for the broader Rust ecosystem.

## License note for fastembed-rs

Distributing this registration does NOT redistribute the model weights — fastembed-rs downloads from HuggingFace at runtime. Users who choose to load `JinaEmbeddingsV5TextNano` are agreeing to CC BY-NC 4.0 with Jina AI directly. The rustdoc on the variant calls this out.
