### PR TITLE
feat: configurable ONNX Runtime intra-op thread count (with_intra_threads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ let mut model = TextEmbedding::try_new(
     InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true),
 )?;
 
+// Cap ONNX Runtime intra-op threads (e.g. to limit CPU usage on a laptop).
+// By default (`None`) every available CPU core is used.
+let mut model = TextEmbedding::try_new(
+    InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_intra_threads(4),
+)?;
+
 let documents = vec![
     "passage: Hello, World!",
     "query: Hello, World!",

--- a/README.md
+++ b/README.md
@@ -126,13 +126,7 @@ let mut model = TextEmbedding::try_new(Default::default())?;
 
 // With custom options
 let mut model = TextEmbedding::try_new(
-    InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true),
-)?;
-
-// Cap ONNX Runtime intra-op threads (e.g. to limit CPU usage on a laptop).
-// By default (`None`) every available CPU core is used.
-let mut model = TextEmbedding::try_new(
-    InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_intra_threads(4),
+    InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true).with_intra_threads(4),
 )?;
 
 let documents = vec![

--- a/src/bgem3_embedding/impl.rs
+++ b/src/bgem3_embedding/impl.rs
@@ -49,7 +49,10 @@ impl Bgem3Embedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let model_repo = Bgem3Embedding::retrieve_model(
             model_name.clone(),
@@ -98,7 +101,10 @@ impl Bgem3Embedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let session = Session::builder()?
             .with_execution_providers(execution_providers)
@@ -128,7 +134,10 @@ impl Bgem3Embedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let session = Session::builder()?
             .with_execution_providers(execution_providers)

--- a/src/bgem3_embedding/impl.rs
+++ b/src/bgem3_embedding/impl.rs
@@ -46,9 +46,10 @@ impl Bgem3Embedding {
             cache_dir,
             show_download_progress,
             execution_providers,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let model_repo = Bgem3Embedding::retrieve_model(
             model_name.clone(),
@@ -94,9 +95,10 @@ impl Bgem3Embedding {
         let InitOptionsUserDefined {
             execution_providers,
             max_length,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let session = Session::builder()?
             .with_execution_providers(execution_providers)
@@ -123,9 +125,10 @@ impl Bgem3Embedding {
         let InitOptionsUserDefined {
             execution_providers,
             max_length,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let session = Session::builder()?
             .with_execution_providers(execution_providers)

--- a/src/image_embedding/impl.rs
+++ b/src/image_embedding/impl.rs
@@ -46,7 +46,10 @@ impl ImageEmbedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let model_repo = ImageEmbedding::retrieve_model(
             model_name.clone(),
@@ -104,7 +107,10 @@ impl ImageEmbedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let preprocessor = Compose::from_bytes(model.preprocessor_file)?;
 

--- a/src/image_embedding/impl.rs
+++ b/src/image_embedding/impl.rs
@@ -43,9 +43,10 @@ impl ImageEmbedding {
             execution_providers,
             cache_dir,
             show_download_progress,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let model_repo = ImageEmbedding::retrieve_model(
             model_name.clone(),
@@ -100,9 +101,10 @@ impl ImageEmbedding {
     ) -> anyhow::Result<Self> {
         let ImageInitOptionsUserDefined {
             execution_providers,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let preprocessor = Compose::from_bytes(model.preprocessor_file)?;
 

--- a/src/image_embedding/init.rs
+++ b/src/image_embedding/init.rs
@@ -12,6 +12,10 @@ pub type ImageInitOptions = InitOptions<ImageEmbeddingModel>;
 #[non_exhaustive]
 pub struct ImageInitOptionsUserDefined {
     pub execution_providers: Vec<ExecutionProviderDispatch>,
+    /// Number of intra-op threads for ONNX Runtime. `None` (the default) uses
+    /// every available CPU core via `std::thread::available_parallelism`.
+    /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
+    pub intra_threads: Option<usize>,
 }
 
 impl ImageInitOptionsUserDefined {
@@ -26,6 +30,14 @@ impl ImageInitOptionsUserDefined {
         self.execution_providers = execution_providers;
         self
     }
+
+    /// Set the number of intra-op threads ONNX Runtime uses. By default
+    /// (`None`) all available CPU cores are used; capping this limits CPU
+    /// usage at the cost of per-inference throughput.
+    pub fn with_intra_threads(mut self, intra_threads: usize) -> Self {
+        self.intra_threads = Some(intra_threads);
+        self
+    }
 }
 
 /// Convert ImageInitOptions to ImageInitOptionsUserDefined
@@ -35,6 +47,7 @@ impl From<ImageInitOptions> for ImageInitOptionsUserDefined {
     fn from(options: ImageInitOptions) -> Self {
         ImageInitOptionsUserDefined {
             execution_providers: options.execution_providers,
+            intra_threads: options.intra_threads,
         }
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,6 +14,10 @@ pub struct InitOptionsWithLength<M> {
     pub cache_dir: PathBuf,
     pub show_download_progress: bool,
     pub max_length: usize,
+    /// Number of intra-op threads for ONNX Runtime. `None` (the default) uses
+    /// every available CPU core via `std::thread::available_parallelism`.
+    /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
+    pub intra_threads: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -23,6 +27,10 @@ pub struct InitOptions<M> {
     pub execution_providers: Vec<ExecutionProviderDispatch>,
     pub cache_dir: PathBuf,
     pub show_download_progress: bool,
+    /// Number of intra-op threads for ONNX Runtime. `None` (the default) uses
+    /// every available CPU core via `std::thread::available_parallelism`.
+    /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
+    pub intra_threads: Option<usize>,
 }
 
 impl<M: Default + HasMaxLength> Default for InitOptionsWithLength<M> {
@@ -33,6 +41,7 @@ impl<M: Default + HasMaxLength> Default for InitOptionsWithLength<M> {
             cache_dir: get_cache_dir().into(),
             show_download_progress: true,
             max_length: M::MAX_LENGTH,
+            intra_threads: None,
         }
     }
 }
@@ -44,6 +53,7 @@ impl<M: Default> Default for InitOptions<M> {
             execution_providers: Default::default(),
             cache_dir: get_cache_dir().into(),
             show_download_progress: true,
+            intra_threads: None,
         }
     }
 }
@@ -78,6 +88,14 @@ impl<M: Default + HasMaxLength> InitOptionsWithLength<M> {
         self
     }
 
+    /// Set the number of intra-op threads ONNX Runtime uses. By default
+    /// (`None`) all available CPU cores are used; capping this limits CPU
+    /// usage at the cost of per-inference throughput.
+    pub fn with_intra_threads(mut self, intra_threads: usize) -> Self {
+        self.intra_threads = Some(intra_threads);
+        self
+    }
+
     /// Set whether to show download progress
     pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
         self.show_download_progress = show_download_progress;
@@ -109,9 +127,30 @@ impl<M: Default> InitOptions<M> {
         self
     }
 
+    /// Set the number of intra-op threads ONNX Runtime uses. By default
+    /// (`None`) all available CPU cores are used; capping this limits CPU
+    /// usage at the cost of per-inference throughput.
+    pub fn with_intra_threads(mut self, intra_threads: usize) -> Self {
+        self.intra_threads = Some(intra_threads);
+        self
+    }
+
     /// Set whether to show download progress
     pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
         self.show_download_progress = show_download_progress;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intra_threads_defaults_none_and_builder_sets() {
+        let o = InitOptions::<crate::ImageEmbeddingModel>::default();
+        assert_eq!(o.intra_threads, None);
+        let o = o.with_intra_threads(4);
+        assert_eq!(o.intra_threads, Some(4));
     }
 }

--- a/src/reranking/impl.rs
+++ b/src/reranking/impl.rs
@@ -66,7 +66,10 @@ impl TextRerank {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let cache = Cache::new(cache_dir);
         let api = ApiBuilder::from_cache(cache)
@@ -114,7 +117,10 @@ impl TextRerank {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let mut session = Session::builder()?
             .with_execution_providers(execution_providers)

--- a/src/reranking/impl.rs
+++ b/src/reranking/impl.rs
@@ -63,9 +63,10 @@ impl TextRerank {
             execution_providers,
             cache_dir,
             show_download_progress,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let cache = Cache::new(cache_dir);
         let api = ApiBuilder::from_cache(cache)
@@ -110,9 +111,10 @@ impl TextRerank {
         let RerankInitOptionsUserDefined {
             execution_providers,
             max_length,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let mut session = Session::builder()?
             .with_execution_providers(execution_providers)

--- a/src/reranking/init.rs
+++ b/src/reranking/init.rs
@@ -29,6 +29,10 @@ pub type RerankInitOptions = InitOptionsWithLength<RerankerModel>;
 pub struct RerankInitOptionsUserDefined {
     pub execution_providers: Vec<ExecutionProviderDispatch>,
     pub max_length: usize,
+    /// Number of intra-op threads for ONNX Runtime. `None` (the default) uses
+    /// every available CPU core via `std::thread::available_parallelism`.
+    /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
+    pub intra_threads: Option<usize>,
 }
 
 impl Default for RerankInitOptionsUserDefined {
@@ -36,7 +40,18 @@ impl Default for RerankInitOptionsUserDefined {
         Self {
             execution_providers: Default::default(),
             max_length: DEFAULT_MAX_LENGTH,
+            intra_threads: None,
         }
+    }
+}
+
+impl RerankInitOptionsUserDefined {
+    /// Set the number of intra-op threads ONNX Runtime uses. By default
+    /// (`None`) all available CPU cores are used; capping this limits CPU
+    /// usage at the cost of per-inference throughput.
+    pub fn with_intra_threads(mut self, intra_threads: usize) -> Self {
+        self.intra_threads = Some(intra_threads);
+        self
     }
 }
 
@@ -48,6 +63,7 @@ impl From<RerankInitOptions> for RerankInitOptionsUserDefined {
         RerankInitOptionsUserDefined {
             execution_providers: options.execution_providers,
             max_length: options.max_length,
+            intra_threads: options.intra_threads,
         }
     }
 }

--- a/src/sparse_text_embedding/impl.rs
+++ b/src/sparse_text_embedding/impl.rs
@@ -49,7 +49,10 @@ impl SparseTextEmbedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let model_repo = SparseTextEmbedding::retrieve_model(
             model_name.clone(),

--- a/src/sparse_text_embedding/impl.rs
+++ b/src/sparse_text_embedding/impl.rs
@@ -46,9 +46,10 @@ impl SparseTextEmbedding {
             cache_dir,
             show_download_progress,
             execution_providers,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let model_repo = SparseTextEmbedding::retrieve_model(
             model_name.clone(),

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -50,7 +50,10 @@ impl TextEmbedding {
             show_download_progress,
             intra_threads,
         } = options;
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         let model_repo = TextEmbedding::retrieve_model(
             model_name.clone(),
@@ -123,7 +126,10 @@ impl TextEmbedding {
             intra_threads,
         } = options;
 
-        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
+        let threads = match intra_threads {
+            Some(n) => n,
+            None => available_parallelism()?.get(),
+        };
 
         #[cfg(feature = "directml")]
         let has_directml = execution_providers

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -48,8 +48,9 @@ impl TextEmbedding {
             execution_providers,
             cache_dir,
             show_download_progress,
+            intra_threads,
         } = options;
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         let model_repo = TextEmbedding::retrieve_model(
             model_name.clone(),
@@ -119,9 +120,10 @@ impl TextEmbedding {
         let InitOptionsUserDefined {
             execution_providers,
             max_length,
+            intra_threads,
         } = options;
 
-        let threads = available_parallelism()?.get();
+        let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
 
         #[cfg(feature = "directml")]
         let has_directml = execution_providers

--- a/src/text_embedding/init.rs
+++ b/src/text_embedding/init.rs
@@ -27,6 +27,10 @@ pub type TextInitOptions = InitOptionsWithLength<EmbeddingModel>;
 pub struct InitOptionsUserDefined {
     pub execution_providers: Vec<ExecutionProviderDispatch>,
     pub max_length: usize,
+    /// Number of intra-op threads for ONNX Runtime. `None` (the default) uses
+    /// every available CPU core via `std::thread::available_parallelism`.
+    /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
+    pub intra_threads: Option<usize>,
 }
 
 impl InitOptionsUserDefined {
@@ -48,6 +52,14 @@ impl InitOptionsUserDefined {
         self.max_length = max_length;
         self
     }
+
+    /// Set the number of intra-op threads ONNX Runtime uses. By default
+    /// (`None`) all available CPU cores are used; capping this limits CPU
+    /// usage at the cost of per-inference throughput.
+    pub fn with_intra_threads(mut self, intra_threads: usize) -> Self {
+        self.intra_threads = Some(intra_threads);
+        self
+    }
 }
 
 impl Default for InitOptionsUserDefined {
@@ -55,6 +67,7 @@ impl Default for InitOptionsUserDefined {
         Self {
             execution_providers: Default::default(),
             max_length: DEFAULT_MAX_LENGTH,
+            intra_threads: None,
         }
     }
 }
@@ -67,6 +80,7 @@ impl From<TextInitOptions> for InitOptionsUserDefined {
         InitOptionsUserDefined {
             execution_providers: options.execution_providers,
             max_length: options.max_length,
+            intra_threads: options.intra_threads,
         }
     }
 }


### PR DESCRIPTION
## Motivation

Every embedding path hardcodes the ONNX Runtime intra-op thread count to `available_parallelism()` (all CPU cores), with no way to override it:

```rust
let threads = available_parallelism()?.get();
... .with_intra_threads(threads)
```

That's a sensible default for raw throughput, but it means embedding **pegs every core**, which is a problem in latency/UI-sensitive or shared-CPU contexts — desktop apps, laptops, multi-tenant servers — where you want to cap CPU usage even at some throughput cost. Today the only workarounds are OS-level (cgroup/affinity), which don't exist on macOS, or forking the crate.

## What this does

Adds an opt-in `intra_threads: Option<usize>` option and a `with_intra_threads(n)` builder.

```rust
// default: None -> uses every core, exactly as before
let model = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))?;

// opt-in: cap intra-op threads
let model = TextEmbedding::try_new(
    InitOptions::new(EmbeddingModel::BGESmallENV15).with_intra_threads(4),
)?;
```

- **Fully backward compatible**: default is `None`, which preserves the exact current behavior (`available_parallelism()`). When set, it's passed to ort's `SessionBuilder::with_intra_threads`.
- Covered across the whole public API: base `InitOptions<M>` / `InitOptionsWithLength<M>` (text, image, sparse, bgem3, reranking download paths) and the user-defined option structs (`InitOptionsUserDefined`, `ImageInitOptionsUserDefined`, `RerankInitOptionsUserDefined`), with `From` propagation.
- **No dependency changes** (this is the part that sank the earlier #122 — it bundled an unstable `ort` bump; this PR doesn't touch `ort`).

## Implementation

The hardcoded line becomes, at every call site:

```rust
let threads = match intra_threads { Some(n) => n, None => available_parallelism()?.get() };
```

## Tests / docs

- Added a unit test (`init::tests::intra_threads_defaults_none_and_builder_sets`) — no model download / network.
- Added a README snippet.
- `cargo build` + `cargo test --lib intra_threads` pass locally.

Prior art: revives the idea from the abandoned #122, but standalone and without the dependency bump.