### PR TITLE
feat: quantized EmbeddingGemma-300m variants (Q4 4-bit + Q int8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 - [**snowflake/snowflake-arctic-embed-m-long**](https://huggingface.co/snowflake/snowflake-arctic-embed-m-long)
 - [**snowflake/snowflake-arctic-embed-l**](https://huggingface.co/snowflake/snowflake-arctic-embed-l)
 
-Quantized versions are also available for several models above (append `Q` to the model enum variant, e.g., `EmbeddingModel::BGESmallENV15Q`).
+Quantized versions are also available for several models above (append `Q` to the model enum variant, e.g., `EmbeddingModel::BGESmallENV15Q`). EmbeddingGemma additionally ships a 4-bit build as `EmbeddingModel::EmbeddingGemma300MQ4`.
 
 </details>
 

--- a/src/models/text_embedding.rs
+++ b/src/models/text_embedding.rs
@@ -76,6 +76,10 @@ pub enum EmbeddingModel {
     JinaEmbeddingsV2BaseEN,
     /// onnx-community/embeddinggemma-300m-ONNX
     EmbeddingGemma300M,
+    /// Quantized (4-bit) onnx-community/embeddinggemma-300m-ONNX
+    EmbeddingGemma300MQ4,
+    /// Quantized onnx-community/embeddinggemma-300m-ONNX
+    EmbeddingGemma300MQ,
     /// snowflake/snowflake-arctic-embed-xs
     SnowflakeArcticEmbedXS,
     /// Quantized snowflake/snowflake-arctic-embed-xs
@@ -416,6 +420,26 @@ fn init_models_map() -> HashMap<EmbeddingModel, ModelInfo<EmbeddingModel>> {
             model_code: String::from("onnx-community/embeddinggemma-300m-ONNX"),
             model_file: String::from("onnx/model.onnx"),
             additional_files: vec!["onnx/model.onnx_data".to_string()],
+            output_key: Some(crate::OutputKey::ByName("sentence_embedding")),
+        },
+        ModelInfo {
+            model: EmbeddingModel::EmbeddingGemma300MQ4,
+            dim: 768,
+            description: String::from(
+                "Quantized (4-bit) EmbeddingGemma is a 300M parameter from Google",
+            ),
+            model_code: String::from("onnx-community/embeddinggemma-300m-ONNX"),
+            model_file: String::from("onnx/model_q4.onnx"),
+            additional_files: vec!["onnx/model_q4.onnx_data".to_string()],
+            output_key: Some(crate::OutputKey::ByName("sentence_embedding")),
+        },
+        ModelInfo {
+            model: EmbeddingModel::EmbeddingGemma300MQ,
+            dim: 768,
+            description: String::from("Quantized EmbeddingGemma is a 300M parameter from Google"),
+            model_code: String::from("onnx-community/embeddinggemma-300m-ONNX"),
+            model_file: String::from("onnx/model_quantized.onnx"),
+            additional_files: vec!["onnx/model_quantized.onnx_data".to_string()],
             output_key: Some(crate::OutputKey::ByName("sentence_embedding")),
         },
         ModelInfo {

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -258,6 +258,8 @@ impl TextEmbedding {
             EmbeddingModel::JinaEmbeddingsV2BaseEN => Some(Pooling::Mean),
 
             EmbeddingModel::EmbeddingGemma300M => Some(Pooling::Mean),
+            EmbeddingModel::EmbeddingGemma300MQ4 => Some(Pooling::Mean),
+            EmbeddingModel::EmbeddingGemma300MQ => Some(Pooling::Mean),
 
             EmbeddingModel::SnowflakeArcticEmbedXS => Some(Pooling::Cls),
             EmbeddingModel::SnowflakeArcticEmbedXSQ => Some(Pooling::Cls),
@@ -302,6 +304,7 @@ impl TextEmbedding {
             EmbeddingModel::SnowflakeArcticEmbedMQ => QuantizationMode::Dynamic,
             EmbeddingModel::SnowflakeArcticEmbedMLongQ => QuantizationMode::Dynamic,
             EmbeddingModel::SnowflakeArcticEmbedLQ => QuantizationMode::Dynamic,
+            EmbeddingModel::EmbeddingGemma300MQ => QuantizationMode::Dynamic,
             _ => QuantizationMode::None,
         }
     }

--- a/tests/text-embeddings.rs
+++ b/tests/text-embeddings.rs
@@ -67,6 +67,8 @@ fn verify_embeddings(model: &EmbeddingModel, embeddings: &[Embedding]) -> Result
         EmbeddingModel::JinaEmbeddingsV2BaseCode => [-0.31383067, -0.3758629, -0.24878195, -0.35373706],
         EmbeddingModel::JinaEmbeddingsV2BaseEN => [-0.055866606, -0.033922599, 0.012131551, -0.0132129812],
         EmbeddingModel::EmbeddingGemma300M => [0.22703816, 0.6947083, 0.07579082, 1.6958784],
+        EmbeddingModel::EmbeddingGemma300MQ4 => [0.3110208, 0.6683019, 0.38347214, 1.787025],
+        EmbeddingModel::EmbeddingGemma300MQ => [0.11791767, 0.34993136, -0.018153993, 1.4971508],
         EmbeddingModel::SnowflakeArcticEmbedXS => [0.4418098, 0.46424747, 0.37932625, 0.44663674],
         EmbeddingModel::SnowflakeArcticEmbedXSQ => [0.45034444, 0.46853474, 0.38483432, 0.44833523],
         EmbeddingModel::SnowflakeArcticEmbedS => [-0.64302516, -0.63146704, -0.57860875, -0.5829098],


### PR DESCRIPTION
Adds two quantized builds of `google/embeddinggemma-300m` to the predefined model list:

- **`EmbeddingGemma300MQ4`** — 4-bit weight-only (`onnx/model_q4.onnx`, ~188 MB), `QuantizationMode::None`.
- **`EmbeddingGemma300MQ`** — int8 dynamic (`onnx/model_quantized.onnx`, ~295 MB), `QuantizationMode::Dynamic`.

Both reuse the existing ONNX path (`dim: 768`, mean pooling, `sentence_embedding` output). Enum, `init_models_map()`, `pooling()`, `get_quantization_mode()`, README, and pinned test rows updated.

Supersedes the EmbeddingGemma part of #249 (inactive since April 29): same int8 `Q` variant plus a new 4-bit `Q4`. The `Q` entry is aligned with #249 so the two are trivially reconcilable. Happy to fold into #249 instead if you prefer.