### PR TITLE
fix(docs): replace removed doc_auto_cfg with doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! [FastEmbed](https://github.com/Anush008/fastembed-rs) - Fast, light, accurate library built for retrieval embedding generation.
 //!
 //! Local ONNX inference, synchronous, no Tokio. Models download once and run offline thereafter.


### PR DESCRIPTION
`doc_auto_cfg` was removed in Rust 1.92 (merged into `doc_cfg`), breaking the docs.rs nightly build.