### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Potential fix for [https://github.com/Anush008/fastembed-rs/security/code-scanning/4](https://github.com/Anush008/fastembed-rs/security/code-scanning/4)

Add a top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token scopes unless overridden later.

Best fix here (without changing functionality): add:

```yml
permissions:
  contents: read
```

directly under the `on:` trigger section (before `env:` is fine). This satisfies CodeQL and documents intended token scope. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
