### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Potential fix for [https://github.com/Anush008/fastembed-rs/security/code-scanning/5](https://github.com/Anush008/fastembed-rs/security/code-scanning/5)

Add an explicit workflow-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token access unless overridden.  
Best single fix without changing functionality: add

```yml
permissions:
  contents: read
```

near the top level (after `on:` block is a standard location). This satisfies CodeQL’s requirement and documents intended token scope. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
