### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Potential fix for [https://github.com/Anush008/fastembed-rs/security/code-scanning/1](https://github.com/Anush008/fastembed-rs/security/code-scanning/1)

Add an explicit workflow-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token access.

Best fix here (without changing functionality): define minimal read permissions globally:
- `contents: read` (needed for checkout/repo read operations)
- `packages: read` (safe baseline often recommended for workflows that may read package metadata/artifacts)

This should be inserted near the top-level keys, right after `on:` and before `env:` so it applies to all jobs unless overridden later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
