### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Potential fix for [https://github.com/Anush008/fastembed-rs/security/code-scanning/3](https://github.com/Anush008/fastembed-rs/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token access unless overridden.  
Best fix without changing functionality: set:

```yml
permissions:
  contents: read
```

Place it near the top-level keys (e.g., after `on:` block and before `env:`). This satisfies CodeQL’s requirement and documents intended token scope. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
