### PR TITLE
refactor!: replace anyhow::Error with a typed fastembed::Error enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1" }
+thiserror = "2"
 hf-hub = { version = "0.5.0", default-features = false, optional = true }
 image = { version = "0.25.10", optional = true }
 ndarray = { version = "0.17.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -379,6 +379,40 @@ let model = TextEmbedding::try_new(
 
 When DirectML is detected, fastembed automatically disables memory pattern optimization and parallel execution on the ONNX Runtime session, as required by the DirectML execution provider.
 
+## Error handling
+
+Fastembed returns a typed [`fastembed::Error`](https://docs.rs/fastembed/latest/fastembed/enum.Error.html). The type is re-exported from the crate root. The enum is `#[non_exhaustive]`. New variants can be added in minor releases without breaking `match` arms.
+
+```rust
+use fastembed::{Error, Result, TextEmbedding};
+
+fn load() -> Result<TextEmbedding> {
+    let model = TextEmbedding::try_new(Default::default())?;
+    Ok(model)
+    // ...
+}
+```
+
+To handle an error, match on the variant that applies:
+
+```rust
+use fastembed::{Error, TextEmbedding, TextInitOptions, EmbeddingModel};
+
+match TextEmbedding::try_new(TextInitOptions::new(EmbeddingModel::AllMiniLML6V2)) {
+    Ok(model) => { /* ... */ }
+    Err(Error::ModelRetrieval { file, source }) => {
+        eprintln!("could not fetch {file}: {source}");
+    }
+    /*
+    ...
+    */
+    Err(Error::Ort(err)) => {
+        eprintln!("ONNX runtime error: {err}");
+    }
+    Err(e) => eprintln!("{e}"),
+}
+```
+
 ## LICENSE
 
 [Apache 2.0](https://github.com/Anush008/fastembed-rs/blob/main/LICENSE)

--- a/src/bgem3_embedding/impl.rs
+++ b/src/bgem3_embedding/impl.rs
@@ -1,14 +1,11 @@
 #[cfg(feature = "hf-hub")]
 use crate::common::load_tokenizer_hf_hub;
 use crate::{
-    common::{init_session_builder, load_tokenizer},
+    common::{init_session_builder, load_tokenizer, Error, Result},
     models::bgem3::{models_list, Bgem3Model},
     text_embedding::InitOptionsUserDefined,
     ModelInfo, SparseEmbedding, TokenizerFiles,
 };
-#[cfg(feature = "hf-hub")]
-use anyhow::Context;
-use anyhow::Result;
 #[cfg(feature = "hf-hub")]
 use hf_hub::api::sync::ApiRepo;
 use ndarray::Array;
@@ -48,16 +45,21 @@ impl Bgem3Embedding {
 
         let model_info = Bgem3Embedding::get_model_info(&model_name);
         let model_file_name = &model_info.model_file;
-        let model_file_reference = model_repo
-            .get(model_file_name)
-            .context(format!("Failed to retrieve {} ", model_file_name))?;
+        let model_file_reference =
+            model_repo
+                .get(model_file_name)
+                .map_err(|e| Error::ModelRetrieval {
+                    file: model_file_name.clone(),
+                    source: Box::new(e),
+                })?;
 
         // Download additional files if needed
         if !model_info.additional_files.is_empty() {
             for file in &model_info.additional_files {
-                model_repo
-                    .get(file)
-                    .context(format!("Failed to retrieve {}", file))?;
+                model_repo.get(file).map_err(|e| Error::ModelRetrieval {
+                    file: file.clone(),
+                    source: Box::new(e),
+                })?;
             }
         }
 
@@ -153,7 +155,11 @@ impl Bgem3Embedding {
     ) -> Result<Bgem3EmbeddingOutput> {
         let texts = texts.as_ref();
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
-        anyhow::ensure!(batch_size > 0, "batch_size must be greater than 0");
+        if batch_size == 0 {
+            return Err(Error::InvalidArgument(
+                "batch_size must be greater than 0".into(),
+            ));
+        }
 
         let mut all_dense = Vec::with_capacity(texts.len());
         let mut all_sparse = Vec::with_capacity(texts.len());
@@ -161,14 +167,12 @@ impl Bgem3Embedding {
 
         for batch in texts.chunks(batch_size) {
             let inputs = batch.iter().map(|text| text.as_ref()).collect();
-            let encodings = self.tokenizer.encode_batch(inputs, true).map_err(|e| {
-                anyhow::Error::msg(e.to_string()).context("Failed to encode the batch.")
-            })?;
+            let encodings = self
+                .tokenizer
+                .encode_batch(inputs, true)
+                .map_err(|e| Error::Tokenization(format!("Failed to encode the batch: {e}")))?;
 
-            let encoding_length = encodings
-                .first()
-                .ok_or_else(|| anyhow::anyhow!("Tokenizer returned empty encodings"))?
-                .len();
+            let encoding_length = encodings.first().ok_or(Error::EmptyTokenizations)?.len();
             let current_batch_size = batch.len();
             let max_size = encoding_length * current_batch_size;
 
@@ -187,30 +191,41 @@ impl Bgem3Embedding {
             });
 
             let inputs_ids_array =
-                Array::from_shape_vec((current_batch_size, encoding_length), ids_array)?;
+                Array::from_shape_vec((current_batch_size, encoding_length), ids_array)
+                    .map_err(|e| Error::InvalidShape(e.to_string()))?;
             let attention_mask_array =
-                Array::from_shape_vec((current_batch_size, encoding_length), mask_array)?;
+                Array::from_shape_vec((current_batch_size, encoding_length), mask_array)
+                    .map_err(|e| Error::InvalidShape(e.to_string()))?;
             let token_type_ids_array =
-                Array::from_shape_vec((current_batch_size, encoding_length), type_ids_array)?;
+                Array::from_shape_vec((current_batch_size, encoding_length), type_ids_array)
+                    .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
             let mut session_inputs = ort::inputs![
-                "input_ids" => Value::from_array(inputs_ids_array.clone())?,
-                "attention_mask" => Value::from_array(attention_mask_array.clone())?,
+                "input_ids" => Value::from_array(inputs_ids_array.clone())
+                    .map_err(|e| Error::OrtSession(e.to_string()))?,
+                "attention_mask" => Value::from_array(attention_mask_array.clone())
+                    .map_err(|e| Error::OrtSession(e.to_string()))?,
             ];
 
             if self.need_token_type_ids {
                 session_inputs.push((
                     "token_type_ids".into(),
-                    Value::from_array(token_type_ids_array)?.into(),
+                    Value::from_array(token_type_ids_array)
+                        .map_err(|e| Error::OrtSession(e.to_string()))?
+                        .into(),
                 ));
             }
 
-            let outputs = self.session.run(session_inputs)?;
-            anyhow::ensure!(
-                outputs.len() >= 3,
-                "BGE-M3 expects the model to return 3 outputs (dense, sparse, colbert), got {}",
-                outputs.len()
-            );
+            let outputs = self
+                .session
+                .run(session_inputs)
+                .map_err(|e| Error::OrtSession(e.to_string()))?;
+            if outputs.len() < 3 {
+                return Err(Error::Other(format!(
+                    "BGE-M3 expects the model to return 3 outputs (dense, sparse, colbert), got {}",
+                    outputs.len()
+                )));
+            }
 
             // gpahal/bge-m3-onnx-int8 returns outputs in this exact order:
             // outputs[0] -> dense_vecs: [batch_size, 1024]
@@ -219,9 +234,12 @@ impl Bgem3Embedding {
 
             // Dense vecs
             let dense_output = &outputs[0];
-            let (dense_shape, dense_data) = dense_output.try_extract_tensor::<f32>()?;
+            let (dense_shape, dense_data) = dense_output
+                .try_extract_tensor::<f32>()
+                .map_err(|e| Error::TensorExtraction(e.to_string()))?;
             let dense_shape: Vec<usize> = dense_shape.iter().map(|&d| d as usize).collect();
-            let dense_view = ndarray::ArrayViewD::from_shape(dense_shape.as_slice(), dense_data)?;
+            let dense_view = ndarray::ArrayViewD::from_shape(dense_shape.as_slice(), dense_data)
+                .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
             for row in dense_view.rows() {
                 all_dense.push(row.to_vec());
@@ -229,14 +247,17 @@ impl Bgem3Embedding {
 
             // Sparse vecs
             let sparse_output = &outputs[1];
-            let (sparse_shape, sparse_data) = sparse_output.try_extract_tensor::<f32>()?;
+            let (sparse_shape, sparse_data) = sparse_output
+                .try_extract_tensor::<f32>()
+                .map_err(|e| Error::TensorExtraction(e.to_string()))?;
             let sparse_shape: Vec<usize> = sparse_shape.iter().map(|&d| d as usize).collect();
-            anyhow::ensure!(
-                sparse_shape.len() == 3,
-                "BGE-M3 sparse output must be rank-3 [batch, seq_len, 1], got shape {sparse_shape:?}"
-            );
-            let sparse_view =
-                ndarray::ArrayViewD::from_shape(sparse_shape.as_slice(), sparse_data)?;
+            if sparse_shape.len() != 3 {
+                return Err(Error::Other(format!(
+                    "BGE-M3 sparse output must be rank-3 [batch, seq_len, 1], got shape {sparse_shape:?}"
+                )));
+            }
+            let sparse_view = ndarray::ArrayViewD::from_shape(sparse_shape.as_slice(), sparse_data)
+                .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
             // Special tokens to skip: XLM-RoBERTa: CLS=0, PAD=1, EOS=2, UNK=3
             const SPECIAL_TOKENS: [i64; 4] = [0, 1, 2, 3];
@@ -271,14 +292,18 @@ impl Bgem3Embedding {
 
             // ColBERT vecs
             let colbert_output = &outputs[2];
-            let (colbert_shape, colbert_data) = colbert_output.try_extract_tensor::<f32>()?;
+            let (colbert_shape, colbert_data) = colbert_output
+                .try_extract_tensor::<f32>()
+                .map_err(|e| Error::TensorExtraction(e.to_string()))?;
             let colbert_shape: Vec<usize> = colbert_shape.iter().map(|&d| d as usize).collect();
-            anyhow::ensure!(
-                colbert_shape.len() == 3 && colbert_shape[1] < encoding_length,
-                "BGE-M3 colbert output must be rank-3 [batch, seq_len - 1, dim] with seq_len - 1 < {encoding_length}, got shape {colbert_shape:?}"
-            );
+            if colbert_shape.len() != 3 || colbert_shape[1] >= encoding_length {
+                return Err(Error::Other(format!(
+                    "BGE-M3 colbert output must be rank-3 [batch, seq_len - 1, dim] with seq_len - 1 < {encoding_length}, got shape {colbert_shape:?}"
+                )));
+            }
             let colbert_view =
-                ndarray::ArrayViewD::from_shape(colbert_shape.as_slice(), colbert_data)?;
+                ndarray::ArrayViewD::from_shape(colbert_shape.as_slice(), colbert_data)
+                    .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
             // Shape of colbert_view is [batch_size, seq_len - 1, 1024]
             let colbert_seq_len = colbert_shape[1]; // seq_len - 1

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 #[cfg(feature = "hf-hub")]
 use hf_hub::api::sync::{ApiBuilder, ApiRepo};
 use ort::{
@@ -24,8 +23,72 @@ pub struct SparseEmbedding {
 /// Type alias for the embedding vector
 pub type Embedding = Vec<f32>;
 
-/// Type alias for the error type
-pub type Error = anyhow::Error;
+/// Error type returned by fastembed.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("Failed to retrieve model file '{file}'")]
+    ModelRetrieval {
+        file: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Invalid tokenizer configuration: {0}")]
+    TokenizerConfig(String),
+
+    #[error("Failed to tokenize input: {0}")]
+    Tokenization(String),
+
+    #[error("Tokenizer returned empty encodings for the batch")]
+    EmptyTokenizations,
+
+    #[error("ONNX runtime error: {0}")]
+    Ort(#[from] ort::Error),
+
+    #[error("Failed to build ONNX session: {0}")]
+    OrtBuilder(String),
+
+    #[error("ONNX session error: {0}")]
+    OrtSession(String),
+
+    #[error("Output tensor '{key}' not found")]
+    OutputKeyMissing { key: String },
+
+    #[error("Failed to extract tensor: {0}")]
+    TensorExtraction(String),
+
+    #[error("Failed to decode image: {0}")]
+    ImageDecode(String),
+
+    #[error("Invalid preprocessor configuration: {0}")]
+    PreprocessorConfig(String),
+
+    #[error("Image transform error: {0}")]
+    ImageTransform(String),
+
+    #[error("Invalid tensor shape: {0}")]
+    InvalidShape(String),
+
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Type alias for `Result` returning the fastembed [`Error`] type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(feature = "hf-hub")]
+impl From<hf_hub::api::sync::ApiError> for Error {
+    fn from(e: hf_hub::api::sync::ApiError) -> Self {
+        Error::Other(format!("HuggingFace API error: {e}"))
+    }
+}
 
 // Tokenizer files for "bring your own" models
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,14 +155,18 @@ pub fn load_tokenizer(tokenizer_files: TokenizerFiles, max_length: usize) -> Res
     let model_max_length = tokenizer_config["model_max_length"]
         .as_f64()
         .ok_or_else(|| {
-            anyhow::anyhow!("tokenizer_config.json is missing a numeric `model_max_length` field")
+            Error::TokenizerConfig(
+                "tokenizer_config.json is missing a numeric `model_max_length` field".into(),
+            )
         })? as f32;
     let max_length = max_length.min(model_max_length as usize);
     let pad_id = config["pad_token_id"].as_u64().unwrap_or(0) as u32;
     let pad_token: String = tokenizer_config["pad_token"]
         .as_str()
         .ok_or_else(|| {
-            anyhow::anyhow!("tokenizer_config.json is missing a string `pad_token` field")
+            Error::TokenizerConfig(
+                "tokenizer_config.json is missing a string `pad_token` field".into(),
+            )
         })?
         .into();
 
@@ -115,7 +182,7 @@ pub fn load_tokenizer(tokenizer_files: TokenizerFiles, max_length: usize) -> Res
             max_length,
             ..Default::default()
         }))
-        .map_err(anyhow::Error::msg)?
+        .map_err(|e| Error::TokenizerConfig(e.to_string()))?
         .clone();
     if let serde_json::Value::Object(root_object) = special_tokens_map {
         for (_, value) in root_object.iter() {
@@ -172,7 +239,7 @@ pub fn pull_from_hf(
     model_name: String,
     default_cache_dir: PathBuf,
     show_download_progress: bool,
-) -> anyhow::Result<ApiRepo> {
+) -> Result<ApiRepo> {
     use std::env;
 
     let cache_dir = env::var("HF_HOME")
@@ -185,7 +252,8 @@ pub fn pull_from_hf(
         .with_cache_dir(cache_dir)
         .with_endpoint(endpoint)
         .with_progress(show_download_progress)
-        .build()?;
+        .build()
+        .map_err(|e| Error::Other(format!("Failed to initialize HuggingFace API: {e}")))?;
 
     let repo = api.model(model_name);
     Ok(repo)
@@ -194,7 +262,7 @@ pub fn pull_from_hf(
 pub(crate) fn init_session_builder(
     execution_providers: Vec<ExecutionProviderDispatch>,
     intra_threads: Option<usize>,
-) -> anyhow::Result<SessionBuilder> {
+) -> Result<SessionBuilder> {
     let threads = match intra_threads {
         Some(n) => n,
         None => std::thread::available_parallelism()?.get(),
@@ -207,7 +275,7 @@ pub(crate) fn init_session_builder(
     #[cfg(not(feature = "directml"))]
     let has_directml = false;
 
-    let builder_error = |err: ort::Error<SessionBuilder>| anyhow::Error::msg(err.to_string());
+    let builder_error = |err: ort::Error<SessionBuilder>| Error::OrtBuilder(err.to_string());
 
     let mut builder = ort::session::Session::builder()?
         .with_execution_providers(execution_providers)

--- a/src/image_embedding/impl.rs
+++ b/src/image_embedding/impl.rs
@@ -8,13 +8,10 @@ use std::path::PathBuf;
 use std::{io::Cursor, path::Path};
 
 use crate::{
-    common::{init_session_builder, normalize},
+    common::{init_session_builder, normalize, Error, Result},
     models::image_embedding::models_list,
     Embedding, ImageEmbeddingModel, ModelInfo,
 };
-use anyhow::anyhow;
-#[cfg(feature = "hf-hub")]
-use anyhow::Context;
 
 #[cfg(feature = "hf-hub")]
 use super::ImageInitOptions;
@@ -31,7 +28,7 @@ impl ImageEmbedding {
     ///
     /// Uses the total number of CPUs available as the number of intra-threads
     #[cfg(feature = "hf-hub")]
-    pub fn try_new(options: ImageInitOptions) -> anyhow::Result<Self> {
+    pub fn try_new(options: ImageInitOptions) -> Result<Self> {
         let ImageInitOptions {
             model_name,
             execution_providers,
@@ -46,15 +43,23 @@ impl ImageEmbedding {
             show_download_progress,
         )?;
 
-        let preprocessor_file = model_repo
-            .get("preprocessor_config.json")
-            .context("Failed to retrieve preprocessor_config.json")?;
+        let preprocessor_file =
+            model_repo
+                .get("preprocessor_config.json")
+                .map_err(|e| Error::ModelRetrieval {
+                    file: "preprocessor_config.json".into(),
+                    source: Box::new(e),
+                })?;
         let preprocessor = Compose::from_file(preprocessor_file)?;
 
         let model_file_name = ImageEmbedding::get_model_info(&model_name).model_file;
-        let model_file_reference = model_repo
-            .get(&model_file_name)
-            .context(format!("Failed to retrieve {}", model_file_name))?;
+        let model_file_reference =
+            model_repo
+                .get(&model_file_name)
+                .map_err(|e| Error::ModelRetrieval {
+                    file: model_file_name.clone(),
+                    source: Box::new(e),
+                })?;
 
         let session = init_session_builder(execution_providers, intra_threads)?
             .commit_from_file(model_file_reference)?;
@@ -68,7 +73,7 @@ impl ImageEmbedding {
     pub fn try_new_from_user_defined(
         model: UserDefinedImageEmbeddingModel,
         options: ImageInitOptionsUserDefined,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let ImageInitOptionsUserDefined {
             execution_providers,
             intra_threads,
@@ -96,7 +101,7 @@ impl ImageEmbedding {
         model: ImageEmbeddingModel,
         cache_dir: PathBuf,
         show_download_progress: bool,
-    ) -> anyhow::Result<ApiRepo> {
+    ) -> Result<ApiRepo> {
         use crate::common::pull_from_hf;
 
         pull_from_hf(model.to_string(), cache_dir, show_download_progress)
@@ -120,9 +125,13 @@ impl ImageEmbedding {
         &mut self,
         images: &[&[u8]],
         batch_size: Option<usize>,
-    ) -> anyhow::Result<Vec<Embedding>> {
+    ) -> Result<Vec<Embedding>> {
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
-        anyhow::ensure!(batch_size > 0, "batch_size must be greater than 0");
+        if batch_size == 0 {
+            return Err(Error::InvalidArgument(
+                "batch_size must be greater than 0".into(),
+            ));
+        }
 
         let output = images
             .chunks(batch_size)
@@ -134,13 +143,13 @@ impl ImageEmbedding {
                         image::ImageReader::new(Cursor::new(img))
                             .with_guessed_format()?
                             .decode()
-                            .map_err(|err| anyhow!("image decode: {}", err))
+                            .map_err(|err| Error::ImageDecode(err.to_string()))
                     })
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<Vec<_>>>()?;
 
                 self.embed_images(inputs)
             })
-            .collect::<anyhow::Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()
             .collect();
@@ -156,11 +165,15 @@ impl ImageEmbedding {
         &mut self,
         images: impl AsRef<[S]>,
         batch_size: Option<usize>,
-    ) -> anyhow::Result<Vec<Embedding>> {
+    ) -> Result<Vec<Embedding>> {
         let images = images.as_ref();
         // Determine the batch size, default if not specified
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
-        anyhow::ensure!(batch_size > 0, "batch_size must be greater than 0");
+        if batch_size == 0 {
+            return Err(Error::InvalidArgument(
+                "batch_size must be greater than 0".into(),
+            ));
+        }
 
         let output = images
             .chunks(batch_size)
@@ -171,13 +184,13 @@ impl ImageEmbedding {
                     .map(|img| {
                         image::ImageReader::open(img)?
                             .decode()
-                            .map_err(|err| anyhow!("image decode: {}", err))
+                            .map_err(|err| Error::ImageDecode(err.to_string()))
                     })
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<Vec<_>>>()?;
 
                 self.embed_images(inputs)
             })
-            .collect::<anyhow::Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()
             .collect();
@@ -186,28 +199,35 @@ impl ImageEmbedding {
     }
 
     /// Embed DynamicImages
-    pub fn embed_images(&mut self, imgs: Vec<DynamicImage>) -> anyhow::Result<Vec<Embedding>> {
+    pub fn embed_images(&mut self, imgs: Vec<DynamicImage>) -> Result<Vec<Embedding>> {
         let inputs = imgs
             .into_iter()
             .map(|img| {
                 let pixels = self.preprocessor.transform(TransformData::Image(img))?;
                 match pixels {
                     TransformData::NdArray(array) => Ok(array),
-                    _ => Err(anyhow!("Preprocessor configuration error!")),
+                    _ => Err(Error::PreprocessorConfig(
+                        "Preprocessor configuration error!".into(),
+                    )),
                 }
             })
-            .collect::<anyhow::Result<Vec<Array3<f32>>>>()?;
+            .collect::<Result<Vec<Array3<f32>>>>()?;
 
         // Extract the batch size
         let inputs_view: Vec<ArrayView3<f32>> = inputs.iter().map(|img| img.view()).collect();
-        let pixel_values_array = ndarray::stack(ndarray::Axis(0), &inputs_view)?;
+        let pixel_values_array = ndarray::stack(ndarray::Axis(0), &inputs_view)
+            .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
         let input_name = self.session.inputs()[0].name().to_string();
         let session_inputs = ort::inputs![
-            input_name => Value::from_array(pixel_values_array)?,
+            input_name => Value::from_array(pixel_values_array)
+                .map_err(|e| Error::OrtSession(e.to_string()))?,
         ];
 
-        let outputs = self.session.run(session_inputs)?;
+        let outputs = self
+            .session
+            .run(session_inputs)
+            .map_err(|e| Error::OrtSession(e.to_string()))?;
 
         // Try to get the only output key
         // If multiple, then default to few known keys `image_embeds` and `last_hidden_state`
@@ -215,7 +235,9 @@ impl ImageEmbedding {
             1 => vec![outputs
                 .keys()
                 .next()
-                .ok_or_else(|| anyhow!("Expected one output but found none"))?],
+                .ok_or_else(|| Error::OutputKeyMissing {
+                    key: "<only output>".into(),
+                })?],
             _ => vec!["image_embeds", "last_hidden_state"],
         };
 
@@ -227,9 +249,12 @@ impl ImageEmbedding {
                     .get(key)
                     .and_then(|v| v.try_extract_tensor::<f32>().ok())
             })
-            .ok_or_else(|| anyhow!("Could not extract tensor from any known output key"))?;
+            .ok_or_else(|| {
+                Error::TensorExtraction("Could not extract tensor from any known output key".into())
+            })?;
         let shape: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-        let output_array = ndarray::ArrayViewD::from_shape(shape.as_slice(), data)?;
+        let output_array = ndarray::ArrayViewD::from_shape(shape.as_slice(), data)
+            .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
         let embeddings = match output_array.ndim() {
             3 => {
@@ -252,16 +277,18 @@ impl ImageEmbedding {
                     .outer_iter()
                     .map(|row| {
                         row.as_slice()
-                            .ok_or_else(|| anyhow!("Failed to convert array row to slice"))
+                            .ok_or_else(|| {
+                                Error::Other("Failed to convert array row to slice".into())
+                            })
                             .map(normalize)
                     })
-                    .collect::<anyhow::Result<Vec<_>>>()?
+                    .collect::<Result<Vec<_>>>()?
             }
             _ => {
-                return Err(anyhow!(
+                return Err(Error::InvalidShape(format!(
                     "Unexpected output tensor shape: {:?}",
                     output_array.shape()
-                ))
+                )))
             }
         };
 

--- a/src/image_embedding/utils.rs
+++ b/src/image_embedding/utils.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use crate::common::{Error, Result};
 use image::{imageops::FilterType, DynamicImage, GenericImageView};
 use ndarray::{Array, Array3};
 use std::ops::{Div, Sub};
@@ -11,29 +11,29 @@ pub enum TransformData {
 }
 
 impl TransformData {
-    pub fn image(self) -> anyhow::Result<DynamicImage> {
+    pub fn image(self) -> Result<DynamicImage> {
         match self {
             TransformData::Image(img) => Ok(img),
-            _ => Err(anyhow!("TransformData convert error")),
+            _ => Err(Error::ImageTransform("TransformData convert error".into())),
         }
     }
 
-    pub fn array(self) -> anyhow::Result<Array3<f32>> {
+    pub fn array(self) -> Result<Array3<f32>> {
         match self {
             TransformData::NdArray(array) => Ok(array),
-            _ => Err(anyhow!("TransformData convert error")),
+            _ => Err(Error::ImageTransform("TransformData convert error".into())),
         }
     }
 }
 
 pub trait Transform: Send + Sync {
-    fn transform(&self, images: TransformData) -> anyhow::Result<TransformData>;
+    fn transform(&self, images: TransformData) -> Result<TransformData>;
 }
 
 struct ConvertToRGB;
 
 impl Transform for ConvertToRGB {
-    fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, data: TransformData) -> Result<TransformData> {
         let image = data.image()?;
         let image = image.into_rgb8().into();
         Ok(TransformData::Image(image))
@@ -46,7 +46,7 @@ pub struct Resize {
 }
 
 impl Transform for Resize {
-    fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, data: TransformData) -> Result<TransformData> {
         let image = data.image()?;
         let image = image.resize_exact(self.size.0, self.size.1, self.resample);
         Ok(TransformData::Image(image))
@@ -58,7 +58,7 @@ pub struct CenterCrop {
 }
 
 impl Transform for CenterCrop {
-    fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, data: TransformData) -> Result<TransformData> {
         let mut image = data.image()?;
         let (mut origin_width, mut origin_height) = image.dimensions();
         let (crop_width, crop_height) = self.size;
@@ -101,7 +101,7 @@ impl Transform for CenterCrop {
 struct PILToNDarray;
 
 impl Transform for PILToNDarray {
-    fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, data: TransformData) -> Result<TransformData> {
         match data {
             TransformData::Image(image) => {
                 let image = image.to_rgb8();
@@ -125,7 +125,7 @@ pub struct Rescale {
 }
 
 impl Transform for Rescale {
-    fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, data: TransformData) -> Result<TransformData> {
         let array = data.array()?;
         let array = array * self.scale;
         Ok(TransformData::NdArray(array))
@@ -138,29 +138,35 @@ pub struct Normalize {
 }
 
 impl Transform for Normalize {
-    fn transform(&self, data: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, data: TransformData) -> Result<TransformData> {
         let array = data.array()?;
         let mean = Array::from_vec(self.mean.clone())
             .into_shape_with_order((3, 1, 1))
-            .map_err(|e| anyhow!("Failed to reshape mean array: {}", e))?;
+            .map_err(|e| Error::InvalidShape(format!("Failed to reshape mean array: {e}")))?;
         let std = Array::from_vec(self.std.clone())
             .into_shape_with_order((3, 1, 1))
-            .map_err(|e| anyhow!("Failed to reshape std array: {}", e))?;
+            .map_err(|e| Error::InvalidShape(format!("Failed to reshape std array: {e}")))?;
 
         let shape = array.shape().to_vec();
         match shape.as_slice() {
             [c, h, w] => {
                 let mean_broadcast = mean.broadcast((*c, *h, *w)).ok_or_else(|| {
-                    anyhow!("Failed to broadcast mean array to shape {:?}", (*c, *h, *w))
+                    Error::InvalidShape(format!(
+                        "Failed to broadcast mean array to shape {:?}",
+                        (*c, *h, *w)
+                    ))
                 })?;
                 let std_broadcast = std.broadcast((*c, *h, *w)).ok_or_else(|| {
-                    anyhow!("Failed to broadcast std array to shape {:?}", (*c, *h, *w))
+                    Error::InvalidShape(format!(
+                        "Failed to broadcast std array to shape {:?}",
+                        (*c, *h, *w)
+                    ))
                 })?;
                 let array_normalized = array.sub(mean_broadcast).div(std_broadcast);
                 Ok(TransformData::NdArray(array_normalized))
             }
-            _ => Err(anyhow!(
-                "Transformer convert error. Normalize operator got error shape."
+            _ => Err(Error::ImageTransform(
+                "Transformer convert error. Normalize operator got error shape.".into(),
             )),
         }
     }
@@ -176,20 +182,22 @@ impl Compose {
     }
 
     #[cfg(feature = "hf-hub")]
-    pub fn from_file<P: AsRef<Path>>(file: P) -> anyhow::Result<Self> {
+    pub fn from_file<P: AsRef<Path>>(file: P) -> Result<Self> {
         let content = read_to_string(file)?;
-        let config = serde_json::from_str(&content)?;
+        let config = serde_json::from_str(&content)
+            .map_err(|e| Error::PreprocessorConfig(format!("Invalid preprocessor JSON: {e}")))?;
         load_preprocessor(config)
     }
 
-    pub fn from_bytes<P: AsRef<[u8]>>(bytes: P) -> anyhow::Result<Compose> {
-        let config = serde_json::from_slice(bytes.as_ref())?;
+    pub fn from_bytes<P: AsRef<[u8]>>(bytes: P) -> Result<Compose> {
+        let config = serde_json::from_slice(bytes.as_ref())
+            .map_err(|e| Error::PreprocessorConfig(format!("Invalid preprocessor JSON: {e}")))?;
         load_preprocessor(config)
     }
 }
 
 impl Transform for Compose {
-    fn transform(&self, mut image: TransformData) -> anyhow::Result<TransformData> {
+    fn transform(&self, mut image: TransformData) -> Result<TransformData> {
         for transform in &self.transforms {
             image = transform.transform(image)?;
         }
@@ -197,7 +205,7 @@ impl Transform for Compose {
     }
 }
 
-fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
+fn load_preprocessor(config: serde_json::Value) -> Result<Compose> {
     let mut transformers: Vec<Box<dyn Transform>> = vec![];
     transformers.push(Box::new(ConvertToRGB));
 
@@ -224,8 +232,8 @@ fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
                         resample: FilterType::CatmullRom,
                     }));
                 } else {
-                    return Err(anyhow!(
-                        "Size must contain either 'shortest_edge' or 'height' and 'width'."
+                    return Err(Error::PreprocessorConfig(
+                        "Size must contain either 'shortest_edge' or 'height' and 'width'.".into(),
                     ));
                 }
             }
@@ -233,24 +241,33 @@ fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
             if config["do_center_crop"].as_bool().unwrap_or(false) {
                 let crop_size = config["crop_size"].clone();
                 let (height, width) = if crop_size.is_u64() {
-                    let size = crop_size
-                        .as_u64()
-                        .ok_or_else(|| anyhow!("crop_size must be a valid u64"))?
-                        as u32;
+                    let size = crop_size.as_u64().ok_or_else(|| {
+                        Error::PreprocessorConfig("crop_size must be a valid u64".into())
+                    })? as u32;
                     (size, size)
                 } else if crop_size.is_object() {
                     (
                         crop_size["height"]
                             .as_u64()
                             .map(|height| height as u32)
-                            .ok_or_else(|| anyhow!("crop_size height must be contained"))?,
+                            .ok_or_else(|| {
+                                Error::PreprocessorConfig(
+                                    "crop_size height must be contained".into(),
+                                )
+                            })?,
                         crop_size["width"]
                             .as_u64()
                             .map(|width| width as u32)
-                            .ok_or_else(|| anyhow!("crop_size width must be contained"))?,
+                            .ok_or_else(|| {
+                                Error::PreprocessorConfig(
+                                    "crop_size width must be contained".into(),
+                                )
+                            })?,
                     )
                 } else {
-                    return Err(anyhow!("Invalid crop size: {:?}", crop_size));
+                    return Err(Error::PreprocessorConfig(format!(
+                        "Invalid crop size: {crop_size:?}"
+                    )));
                 };
                 transformers.push(Box::new(CenterCrop {
                     size: (width, height),
@@ -260,7 +277,9 @@ fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
         "ConvNextFeatureExtractor" => {
             let shortest_edge = config["size"]["shortest_edge"].as_u64();
             if shortest_edge.is_none() {
-                return Err(anyhow!("Size dictionary must contain 'shortest_edge' key."));
+                return Err(Error::PreprocessorConfig(
+                    "Size dictionary must contain 'shortest_edge' key.".into(),
+                ));
             }
             let shortest_edge = shortest_edge.unwrap() as u32;
             let crop_pct = config["crop_pct"].as_f64().unwrap_or(0.875);
@@ -302,8 +321,8 @@ fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
                         resample: FilterType::CatmullRom,
                     }));
                 } else {
-                    return Err(anyhow!(
-                        "Size must contain either 'shortest_edge' or 'height' and 'width'."
+                    return Err(Error::PreprocessorConfig(
+                        "Size must contain either 'shortest_edge' or 'height' and 'width'.".into(),
                     ));
                 }
             }
@@ -311,31 +330,44 @@ fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
             if config["do_center_crop"].as_bool().unwrap_or(false) {
                 let crop_size = config["crop_size"].clone();
                 let (height, width) = if crop_size.is_u64() {
-                    let size = crop_size
-                        .as_u64()
-                        .ok_or_else(|| anyhow!("crop_size must be a valid u64"))?
-                        as u32;
+                    let size = crop_size.as_u64().ok_or_else(|| {
+                        Error::PreprocessorConfig("crop_size must be a valid u64".into())
+                    })? as u32;
                     (size, size)
                 } else if crop_size.is_object() {
                     (
                         crop_size["height"]
                             .as_u64()
                             .map(|height| height as u32)
-                            .ok_or_else(|| anyhow!("crop_size height must be contained"))?,
+                            .ok_or_else(|| {
+                                Error::PreprocessorConfig(
+                                    "crop_size height must be contained".into(),
+                                )
+                            })?,
                         crop_size["width"]
                             .as_u64()
                             .map(|width| width as u32)
-                            .ok_or_else(|| anyhow!("crop_size width must be contained"))?,
+                            .ok_or_else(|| {
+                                Error::PreprocessorConfig(
+                                    "crop_size width must be contained".into(),
+                                )
+                            })?,
                     )
                 } else {
-                    return Err(anyhow!("Invalid crop size: {:?}", crop_size));
+                    return Err(Error::PreprocessorConfig(format!(
+                        "Invalid crop size: {crop_size:?}"
+                    )));
                 };
                 transformers.push(Box::new(CenterCrop {
                     size: (width, height),
                 }));
             }
         }
-        mode => return Err(anyhow!("Preprocessor {} is not supported", mode)),
+        mode => {
+            return Err(Error::PreprocessorConfig(format!(
+                "Preprocessor {mode} is not supported"
+            )));
+        }
     }
 
     transformers.push(Box::new(PILToNDarray));
@@ -350,24 +382,24 @@ fn load_preprocessor(config: serde_json::Value) -> anyhow::Result<Compose> {
     if config["do_normalize"].as_bool().unwrap_or(false) {
         let mean = config["image_mean"]
             .as_array()
-            .ok_or(anyhow!("image_mean must be contained"))?
+            .ok_or_else(|| Error::PreprocessorConfig("image_mean must be contained".into()))?
             .iter()
             .map(|value| {
                 value
                     .as_f64()
                     .map(|num| num as f32)
-                    .ok_or(anyhow!("image_mean must be float"))
+                    .ok_or_else(|| Error::PreprocessorConfig("image_mean must be float".into()))
             })
             .collect::<Result<Vec<f32>>>()?;
         let std = config["image_std"]
             .as_array()
-            .ok_or(anyhow!("image_std must be contained"))?
+            .ok_or_else(|| Error::PreprocessorConfig("image_std must be contained".into()))?
             .iter()
             .map(|value| {
                 value
                     .as_f64()
                     .map(|num| num as f32)
-                    .ok_or(anyhow!("image_std must be float"))
+                    .ok_or_else(|| Error::PreprocessorConfig("image_std must be float".into()))
             })
             .collect::<Result<Vec<f32>>>()?;
         transformers.push(Box::new(Normalize { mean, std }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
  ```
  use fastembed::{TextEmbedding, TextInitOptions, EmbeddingModel};
 
-# fn model_demo() -> anyhow::Result<()> {
+# fn model_demo() -> fastembed::Result<()> {
  // With default TextInitOptions
  let model = TextEmbedding::try_new(Default::default())?;
 
@@ -52,7 +52,7 @@
  ### Embeddings generation
 ```
 # use fastembed::{TextEmbedding, TextInitOptions, EmbeddingModel};
-# fn embedding_demo() -> anyhow::Result<()> {
+# fn embedding_demo() -> fastembed::Result<()> {
 # let mut model: TextEmbedding = TextEmbedding::try_new(Default::default())?;
  let documents = vec![
     "passage: Hello, World!",
@@ -88,7 +88,7 @@ mod text_embedding;
 
 pub use ort::execution_providers::ExecutionProviderDispatch;
 
-pub use crate::common::{get_cache_dir, Embedding, Error, SparseEmbedding, TokenizerFiles};
+pub use crate::common::{get_cache_dir, Embedding, Error, Result, SparseEmbedding, TokenizerFiles};
 pub use crate::models::{
     model_info::ModelInfo, model_info::RerankerModelInfo, quantization::QuantizationMode,
 };

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -1,5 +1,6 @@
 use ndarray::{Array2, ArrayView, Dim, IxDynImpl};
 
+use crate::common::{Error, Result};
 use crate::pooling;
 
 use super::{OutputKey, OutputPrecedence};
@@ -22,7 +23,7 @@ impl SingleBatchOutput {
     pub fn select_output(
         &self,
         precedence: &impl OutputPrecedence,
-    ) -> anyhow::Result<ArrayView<'_, f32, Dim<IxDynImpl>>> {
+    ) -> Result<ArrayView<'_, f32, Dim<IxDynImpl>>> {
         let ort_output: &ort::value::Value = precedence
             .key_precedence()
             .find_map(|key| match key {
@@ -40,13 +41,13 @@ impl SingleBatchOutput {
                 }
             })
             .ok_or_else(|| {
-                anyhow::Error::msg(format!(
+                Error::Other(format!(
                     "No suitable output found in the outputs. Available outputs: {:?}",
                     self.outputs.iter().map(|(k, _)| k).collect::<Vec<_>>()
                 ))
             })?;
 
-        ort_output.try_extract_array().map_err(anyhow::Error::new)
+        ort_output.try_extract_array().map_err(Error::from)
     }
 
     /// Select the output from the session outputs based on the given precedence and pool it.
@@ -56,7 +57,7 @@ impl SingleBatchOutput {
         &self,
         precedence: &impl OutputPrecedence,
         pooling_opt: Option<pooling::Pooling>,
-    ) -> anyhow::Result<Array2<f32>> {
+    ) -> Result<Array2<f32>> {
         let tensor = self.select_output(precedence)?;
 
         // If there is none pooling, default to cls so as not to break the existing implementations
@@ -112,8 +113,8 @@ impl EmbeddingOutput {
         &self,
         // TODO: Convert this to a trait alias when it's stabilized.
         // https://github.com/rust-lang/rust/issues/41517
-        transformer: impl Fn(&[SingleBatchOutput]) -> anyhow::Result<R>,
-    ) -> anyhow::Result<R> {
+        transformer: impl Fn(&[SingleBatchOutput]) -> Result<R>,
+    ) -> Result<R> {
         transformer(&self.batches)
     }
 }

--- a/src/pooling.rs
+++ b/src/pooling.rs
@@ -1,3 +1,4 @@
+use crate::common::{Error, Result};
 use ndarray::{s, Array2, ArrayView, Dim, Dimension, IxDynImpl};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,11 +16,11 @@ impl Default for Pooling {
     }
 }
 
-pub fn cls(tensor: &ArrayView<f32, Dim<IxDynImpl>>) -> anyhow::Result<Array2<f32>> {
+pub fn cls(tensor: &ArrayView<f32, Dim<IxDynImpl>>) -> Result<Array2<f32>> {
     match tensor.dim().ndim() {
         2 => Ok(tensor.slice(s![.., ..]).to_owned()),
         3 => Ok(tensor.slice(s![.., 0, ..]).to_owned()),
-        _ => Err(anyhow::Error::msg(format!(
+        _ => Err(Error::InvalidShape(format!(
             "Invalid output shape: {shape:?}. Expected 2D or 3D tensor.",
             shape = tensor.dim()
         ))),
@@ -34,7 +35,7 @@ pub fn cls(tensor: &ArrayView<f32, Dim<IxDynImpl>>) -> anyhow::Result<Array2<f32
 pub fn mean(
     token_embeddings: &ArrayView<f32, Dim<IxDynImpl>>,
     attention_mask_array: Array2<i64>,
-) -> anyhow::Result<Array2<f32>> {
+) -> Result<Array2<f32>> {
     let attention_mask_original_dim = attention_mask_array.dim();
 
     if token_embeddings.dim().ndim() == 2 {
@@ -43,7 +44,7 @@ pub fn mean(
         // It can be assumed that pooling is already done within the model.
         return Ok(token_embeddings.slice(s![.., ..]).to_owned());
     } else if token_embeddings.dim().ndim() != 3 {
-        return Err(anyhow::Error::msg(format!(
+        return Err(Error::InvalidShape(format!(
             "Invalid output shape: {shape:?}. Expected 2D or 3D tensor.",
             shape = token_embeddings.dim()
         )));
@@ -60,7 +61,7 @@ pub fn mean(
         .insert_axis(ndarray::Axis(2))
         .broadcast(token_embeddings.dim())
         .ok_or_else(|| {
-            anyhow::Error::msg(format!(
+            Error::InvalidShape(format!(
                 "Could not broadcast attention mask from {:?} to {:?}",
                 attention_mask_original_dim,
                 token_embeddings.dim()

--- a/src/reranking/impl.rs
+++ b/src/reranking/impl.rs
@@ -1,16 +1,12 @@
 #[cfg(feature = "hf-hub")]
-use anyhow::Context;
-use anyhow::Result;
-use ort::{session::Session, value::Value};
-
-#[cfg(feature = "hf-hub")]
 use crate::common::load_tokenizer_hf_hub;
 use crate::{
-    common::{init_session_builder, load_tokenizer},
+    common::{init_session_builder, load_tokenizer, Error, Result},
     models::reranking::reranker_model_list,
     RerankerModel, RerankerModelInfo,
 };
 use ndarray::{s, Array};
+use ort::{session::Session, value::Value};
 use tokenizers::Tokenizer;
 
 #[cfg(feature = "hf-hub")]
@@ -61,16 +57,22 @@ impl TextRerank {
         let model_repo = pull_from_hf(model_name.to_string(), cache_dir, show_download_progress)?;
 
         let model_file_name = TextRerank::get_model_info(&model_name).model_file;
-        let model_file_reference = model_repo.get(&model_file_name).context(format!(
-            "Failed to retrieve model file: {}",
-            model_file_name
-        ))?;
+        let model_file_reference =
+            model_repo
+                .get(&model_file_name)
+                .map_err(|e| Error::ModelRetrieval {
+                    file: model_file_name.clone(),
+                    source: Box::new(e),
+                })?;
         let additional_files = TextRerank::get_model_info(&model_name).additional_files;
         for additional_file in additional_files {
-            let _additional_file_reference = model_repo.get(&additional_file).context(format!(
-                "Failed to retrieve additional file: {}",
-                additional_file
-            ))?;
+            let _additional_file_reference =
+                model_repo
+                    .get(&additional_file)
+                    .map_err(|e| Error::ModelRetrieval {
+                        file: additional_file.clone(),
+                        source: Box::new(e),
+                    })?;
         }
 
         let session = init_session_builder(execution_providers, intra_threads)?
@@ -115,7 +117,11 @@ impl TextRerank {
     ) -> Result<Vec<RerankResult>> {
         let documents = documents.as_ref();
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
-        anyhow::ensure!(batch_size > 0, "batch_size must be greater than 0");
+        if batch_size == 0 {
+            return Err(Error::InvalidArgument(
+                "batch_size must be greater than 0".into(),
+            ));
+        }
         let q = query.as_ref();
 
         let mut scores: Vec<f32> = Vec::with_capacity(documents.len());
@@ -124,12 +130,9 @@ impl TextRerank {
             let encodings = self
                 .tokenizer
                 .encode_batch(inputs, true)
-                .map_err(|e| anyhow::Error::msg(e.to_string()).context("Failed to encode batch"))?;
+                .map_err(|e| Error::Tokenization(format!("Failed to encode batch: {e}")))?;
 
-            let encoding_length = encodings
-                .first()
-                .ok_or_else(|| anyhow::anyhow!("Tokenizer returned empty encodings"))?
-                .len();
+            let encoding_length = encodings.first().ok_or(Error::EmptyTokenizations)?.len();
             let batch_size = batch.len();
             let max_size = encoding_length * batch_size;
 
@@ -147,30 +150,42 @@ impl TextRerank {
                 type_ids_array.extend(type_ids.iter().map(|x| *x as i64));
             });
 
-            let inputs_ids_array = Array::from_shape_vec((batch_size, encoding_length), ids_array)?;
+            let inputs_ids_array = Array::from_shape_vec((batch_size, encoding_length), ids_array)
+                .map_err(|e| Error::InvalidShape(e.to_string()))?;
             let attention_mask_array =
-                Array::from_shape_vec((batch_size, encoding_length), mask_array)?;
+                Array::from_shape_vec((batch_size, encoding_length), mask_array)
+                    .map_err(|e| Error::InvalidShape(e.to_string()))?;
             let token_type_ids_array =
-                Array::from_shape_vec((batch_size, encoding_length), type_ids_array)?;
+                Array::from_shape_vec((batch_size, encoding_length), type_ids_array)
+                    .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
             let mut session_inputs = ort::inputs![
-                "input_ids" => Value::from_array(inputs_ids_array)?,
-                "attention_mask" => Value::from_array(attention_mask_array)?,
+                "input_ids" => Value::from_array(inputs_ids_array)
+                    .map_err(|e| Error::OrtSession(e.to_string()))?,
+                "attention_mask" => Value::from_array(attention_mask_array)
+                    .map_err(|e| Error::OrtSession(e.to_string()))?,
             ];
             if self.need_token_type_ids {
                 session_inputs.push((
                     "token_type_ids".into(),
-                    Value::from_array(token_type_ids_array)?.into(),
+                    Value::from_array(token_type_ids_array)
+                        .map_err(|e| Error::OrtSession(e.to_string()))?
+                        .into(),
                 ));
             }
 
-            let outputs = self.session.run(session_inputs)?;
+            let outputs = self
+                .session
+                .run(session_inputs)
+                .map_err(|e| Error::OrtSession(e.to_string()))?;
             let outputs = outputs
                 .get("logits")
-                .ok_or_else(|| anyhow::Error::msg("Output does not contain 'logits' key"))?
+                .ok_or_else(|| Error::OutputKeyMissing {
+                    key: "logits".into(),
+                })?
                 .try_extract_array()
                 .map_err(|e| {
-                    anyhow::Error::msg(format!("Failed to extract logits tensor: {}", e))
+                    Error::TensorExtraction(format!("Failed to extract logits tensor: {e}"))
                 })?;
             let batch_scores: Vec<f32> = outputs
                 .slice(s![.., 0])

--- a/src/sparse_text_embedding/impl.rs
+++ b/src/sparse_text_embedding/impl.rs
@@ -1,12 +1,10 @@
 #[cfg(feature = "hf-hub")]
 use crate::common::{init_session_builder, load_tokenizer_hf_hub};
 use crate::{
+    common::{Error, Result},
     models::sparse::{models_list, SparseModel},
     ModelInfo, SparseEmbedding,
 };
-#[cfg(feature = "hf-hub")]
-use anyhow::Context;
-use anyhow::Result;
 #[cfg(feature = "hf-hub")]
 use hf_hub::api::sync::ApiRepo;
 use ndarray::{Array, ArrayViewD, Axis, CowArray, Dim};
@@ -48,16 +46,21 @@ impl SparseTextEmbedding {
 
         let model_info = SparseTextEmbedding::get_model_info(&model_name);
         let model_file_name = &model_info.model_file;
-        let model_file_reference = model_repo
-            .get(model_file_name)
-            .context(format!("Failed to retrieve {} ", model_file_name))?;
+        let model_file_reference =
+            model_repo
+                .get(model_file_name)
+                .map_err(|e| Error::ModelRetrieval {
+                    file: model_file_name.clone(),
+                    source: Box::new(e),
+                })?;
 
         // Download additional files if needed (e.g., model.onnx.data for large models)
         if !model_info.additional_files.is_empty() {
             for file in &model_info.additional_files {
-                model_repo
-                    .get(file)
-                    .context(format!("Failed to retrieve {}", file))?;
+                model_repo.get(file).map_err(|e| Error::ModelRetrieval {
+                    file: file.clone(),
+                    source: Box::new(e),
+                })?;
             }
         }
 
@@ -119,22 +122,24 @@ impl SparseTextEmbedding {
         let texts = texts.as_ref();
         // Determine the batch size, default if not specified
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
-        anyhow::ensure!(batch_size > 0, "batch_size must be greater than 0");
+        if batch_size == 0 {
+            return Err(Error::InvalidArgument(
+                "batch_size must be greater than 0".into(),
+            ));
+        }
 
         let output = texts
             .chunks(batch_size)
             .map(|batch| {
                 // Encode the texts in the batch
                 let inputs = batch.iter().map(|text| text.as_ref()).collect();
-                let encodings = self.tokenizer.encode_batch(inputs, true).map_err(|e| {
-                    anyhow::Error::msg(e.to_string()).context("Failed to encode the batch.")
-                })?;
+                let encodings = self
+                    .tokenizer
+                    .encode_batch(inputs, true)
+                    .map_err(|e| Error::Tokenization(format!("Failed to encode the batch: {e}")))?;
 
                 // Extract the encoding length and batch size
-                let encoding_length = encodings
-                    .first()
-                    .ok_or_else(|| anyhow::anyhow!("Tokenizer returned empty encodings"))?
-                    .len();
+                let encoding_length = encodings.first().ok_or(Error::EmptyTokenizations)?.len();
                 let batch_size = batch.len();
 
                 let max_size = encoding_length * batch_size;
@@ -155,54 +160,74 @@ impl SparseTextEmbedding {
                 });
 
                 let inputs_ids_array =
-                    Array::from_shape_vec((batch_size, encoding_length), ids_array)?;
+                    Array::from_shape_vec((batch_size, encoding_length), ids_array)
+                        .map_err(|e| Error::InvalidShape(e.to_string()))?;
                 let attention_mask_array =
-                    Array::from_shape_vec((batch_size, encoding_length), mask_array)?;
+                    Array::from_shape_vec((batch_size, encoding_length), mask_array)
+                        .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
                 let token_type_ids_array =
-                    Array::from_shape_vec((batch_size, encoding_length), type_ids_array)?;
+                    Array::from_shape_vec((batch_size, encoding_length), type_ids_array)
+                        .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
                 let mut session_inputs = ort::inputs![
-                    "input_ids" => Value::from_array(inputs_ids_array.clone())?,
-                    "attention_mask" => Value::from_array(attention_mask_array.clone())?,
+                    "input_ids" => Value::from_array(inputs_ids_array.clone())
+                        .map_err(|e| Error::OrtSession(e.to_string()))?,
+                    "attention_mask" => Value::from_array(attention_mask_array.clone())
+                        .map_err(|e| Error::OrtSession(e.to_string()))?,
                 ];
 
                 if self.need_token_type_ids {
                     session_inputs.push((
                         "token_type_ids".into(),
-                        Value::from_array(token_type_ids_array)?.into(),
+                        Value::from_array(token_type_ids_array)
+                            .map_err(|e| Error::OrtSession(e.to_string()))?
+                            .into(),
                     ));
                 }
 
-                let outputs = self.session.run(session_inputs)?;
+                let outputs = self
+                    .session
+                    .run(session_inputs)
+                    .map_err(|e| Error::OrtSession(e.to_string()))?;
 
                 let embeddings = match self.model {
                     SparseModel::SPLADEPPV1 => {
                         let last_hidden_state_key = match outputs.len() {
-                            1 => outputs.keys().next().ok_or_else(|| {
-                                anyhow::anyhow!("Expected one output but found none")
-                            })?,
+                            1 => outputs
+                                .keys()
+                                .next()
+                                .ok_or_else(|| Error::OutputKeyMissing {
+                                    key: "<only output>".into(),
+                                })?,
                             _ => "last_hidden_state",
                         };
 
-                        let (shape, data) =
-                            outputs[last_hidden_state_key].try_extract_tensor::<f32>()?;
+                        let (shape, data) = outputs[last_hidden_state_key]
+                            .try_extract_tensor::<f32>()
+                            .map_err(|e| Error::TensorExtraction(e.to_string()))?;
                         let shape: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-                        let output_array = ndarray::ArrayViewD::from_shape(shape.as_slice(), data)?;
+                        let output_array = ndarray::ArrayViewD::from_shape(shape.as_slice(), data)
+                            .map_err(|e| Error::InvalidShape(e.to_string()))?;
                         let attention_mask_cow = ndarray::CowArray::from(&attention_mask_array);
 
                         Self::post_process_splade(&output_array, &attention_mask_cow)
                     }
                     SparseModel::BGEM3 => {
-                        let output_key = outputs
-                            .keys()
-                            .next()
-                            .ok_or_else(|| anyhow::anyhow!("Expected at least one output"))?;
+                        let output_key =
+                            outputs
+                                .keys()
+                                .next()
+                                .ok_or_else(|| Error::OutputKeyMissing {
+                                    key: "<first output>".into(),
+                                })?;
 
-                        let (shape, data) = outputs[output_key].try_extract_tensor::<f32>()?;
+                        let (shape, data) = outputs[output_key]
+                            .try_extract_tensor::<f32>()
+                            .map_err(|e| Error::TensorExtraction(e.to_string()))?;
                         let shape: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
-                        let hidden_states =
-                            ndarray::ArrayViewD::from_shape(shape.as_slice(), data)?;
+                        let hidden_states = ndarray::ArrayViewD::from_shape(shape.as_slice(), data)
+                            .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
                         Self::post_process_bgem3(
                             &hidden_states,

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -3,15 +3,12 @@
 #[cfg(feature = "hf-hub")]
 use crate::common::load_tokenizer_hf_hub;
 use crate::{
-    common::{init_session_builder, load_tokenizer},
+    common::{init_session_builder, load_tokenizer, Error, Result},
     models::{text_embedding::models_list, ModelTrait},
     pooling::Pooling,
     Embedding, EmbeddingModel, EmbeddingOutput, ModelInfo, OutputKey, QuantizationMode,
     SingleBatchOutput,
 };
-#[cfg(feature = "hf-hub")]
-use anyhow::Context;
-use anyhow::Result;
 #[cfg(feature = "hf-hub")]
 use hf_hub::api::sync::ApiRepo;
 use ndarray::Array;
@@ -51,15 +48,20 @@ impl TextEmbedding {
 
         let model_info = TextEmbedding::get_model_info(&model_name)?;
         let model_file_name = &model_info.model_file;
-        let model_file_reference = model_repo
-            .get(model_file_name)
-            .context(format!("Failed to retrieve {}", model_file_name))?;
+        let model_file_reference =
+            model_repo
+                .get(model_file_name)
+                .map_err(|e| Error::ModelRetrieval {
+                    file: model_file_name.clone(),
+                    source: Box::new(e),
+                })?;
 
         if !model_info.additional_files.is_empty() {
             for file in &model_info.additional_files {
-                model_repo
-                    .get(file)
-                    .context(format!("Failed to retrieve {}", file))?;
+                model_repo.get(file).map_err(|e| Error::ModelRetrieval {
+                    file: file.clone(),
+                    source: Box::new(e),
+                })?;
             }
         }
 
@@ -94,7 +96,7 @@ impl TextEmbedding {
 
         let session = {
             let builder_error = |err: ort::Error<ort::session::builder::SessionBuilder>| {
-                anyhow::Error::msg(err.to_string())
+                Error::OrtBuilder(err.to_string())
             };
             let mut session_builder = init_session_builder(execution_providers, intra_threads)?;
 
@@ -148,7 +150,7 @@ impl TextEmbedding {
         model: EmbeddingModel,
         cache_dir: PathBuf,
         show_download_progress: bool,
-    ) -> anyhow::Result<ApiRepo> {
+    ) -> Result<ApiRepo> {
         use crate::common::pull_from_hf;
 
         let model_code = TextEmbedding::get_model_info(&model)?.model_code.clone();
@@ -290,7 +292,7 @@ impl TextEmbedding {
     /// Get ModelInfo from EmbeddingModel
     pub fn get_model_info(model: &EmbeddingModel) -> Result<&ModelInfo<EmbeddingModel>> {
         EmbeddingModel::get_model_info(model).ok_or_else(|| {
-            anyhow::Error::msg(format!(
+            Error::InvalidArgument(format!(
                 "Model {model:?} not found. Please check if the model is supported \
                 by the current version."
             ))
@@ -331,12 +333,13 @@ impl TextEmbedding {
             QuantizationMode::Dynamic => {
                 if let Some(batch_size) = batch_size {
                     if batch_size < texts.len() {
-                        Err(anyhow::Error::msg(
+                        Err(Error::InvalidArgument(
                             "Dynamic quantization cannot be used with batching. \
                             This is due to the dynamic quantization process adjusting \
                             the data range to fit each batch, making the embeddings \
                             incompatible across batches. Try specifying a batch size \
-                            of `None`, or use a model with static or no quantization.",
+                            of `None`, or use a model with static or no quantization."
+                                .into(),
                         ))
                     } else {
                         Ok(texts.len())
@@ -347,22 +350,24 @@ impl TextEmbedding {
             }
             _ => Ok(batch_size.unwrap_or(DEFAULT_BATCH_SIZE)),
         }?;
-        anyhow::ensure!(batch_size > 0, "batch_size must be greater than 0");
+        if batch_size == 0 {
+            return Err(Error::InvalidArgument(
+                "batch_size must be greater than 0".into(),
+            ));
+        }
 
         let batches = texts
             .chunks(batch_size)
             .map(|batch| {
                 // Encode the texts in the batch
                 let inputs = batch.iter().map(|text| text.as_ref()).collect();
-                let encodings = self.tokenizer.encode_batch(inputs, true).map_err(|e| {
-                    anyhow::Error::msg(e.to_string()).context("Failed to encode the batch.")
-                })?;
+                let encodings = self
+                    .tokenizer
+                    .encode_batch(inputs, true)
+                    .map_err(|e| Error::Tokenization(format!("Failed to encode the batch: {e}")))?;
 
                 // Extract the encoding length and batch size
-                let encoding_length = encodings
-                    .first()
-                    .ok_or_else(|| anyhow::anyhow!("Tokenizer returned empty encodings"))?
-                    .len();
+                let encoding_length = encodings.first().ok_or(Error::EmptyTokenizations)?.len();
                 let batch_size = batch.len();
 
                 let max_size = encoding_length * batch_size;
@@ -383,11 +388,14 @@ impl TextEmbedding {
                 });
 
                 let inputs_ids_array =
-                    Array::from_shape_vec((batch_size, encoding_length), ids_array)?;
+                    Array::from_shape_vec((batch_size, encoding_length), ids_array)
+                        .map_err(|e| Error::InvalidShape(e.to_string()))?;
                 let attention_mask_array =
-                    Array::from_shape_vec((batch_size, encoding_length), mask_array)?;
+                    Array::from_shape_vec((batch_size, encoding_length), mask_array)
+                        .map_err(|e| Error::InvalidShape(e.to_string()))?;
                 let token_type_ids_array =
-                    Array::from_shape_vec((batch_size, encoding_length), type_ids_array)?;
+                    Array::from_shape_vec((batch_size, encoding_length), type_ids_array)
+                        .map_err(|e| Error::InvalidShape(e.to_string()))?;
 
                 let mut session_inputs = ort::inputs![
                     "input_ids" => Value::from_array(inputs_ids_array)?,
@@ -404,7 +412,7 @@ impl TextEmbedding {
                 let outputs_map = self
                     .session
                     .run(session_inputs)
-                    .map_err(anyhow::Error::new)?
+                    .map_err(|e| Error::OrtSession(e.to_string()))?
                     .into_iter()
                     .map(|(k, v)| (k.to_string(), v))
                     .collect();

--- a/src/text_embedding/output.rs
+++ b/src/text_embedding/output.rs
@@ -1,7 +1,7 @@
 //! Output types and functions for the [`TextEmbedding`] model.
 //!
 use crate::{
-    common::{normalize, Embedding},
+    common::{normalize, Embedding, Error, Result},
     output::{OutputKey, OutputPrecedence, SingleBatchOutput},
     pooling::Pooling,
 };
@@ -28,7 +28,7 @@ pub const OUTPUT_TYPE_PRECEDENCE: &[OutputKey] = &[
 pub fn transformer_with_precedence(
     output_precedence: impl OutputPrecedence,
     pooling: Option<Pooling>,
-) -> impl Fn(&[SingleBatchOutput]) -> anyhow::Result<Vec<Embedding>> {
+) -> impl Fn(&[SingleBatchOutput]) -> Result<Vec<Embedding>> {
     move |batches| {
         // Not using `par_iter` here: the operations here is probably not
         // computationally expensive enough to warrant spinning up costs of the threads.
@@ -44,11 +44,11 @@ pub fn transformer_with_precedence(
                             .map(|row| {
                                 row.as_slice()
                                     .ok_or_else(|| {
-                                        anyhow::anyhow!("Failed to convert array row to slice")
+                                        Error::Other("Failed to convert array row to slice".into())
                                     })
                                     .map(normalize)
                             })
-                            .collect::<anyhow::Result<Vec<Embedding>>>()
+                            .collect::<Result<Vec<Embedding>>>()
                     })
             })
             .try_fold(Vec::new(), |mut acc, res| {

--- a/tests/optimum_cli_export.rs
+++ b/tests/optimum_cli_export.rs
@@ -7,10 +7,10 @@
 //! may not be the default output. This test is to ensure that the correct output key
 //! is used when generating embeddings.
 
-use std::{path::PathBuf, process};
+use std::{io, path::PathBuf, process};
 
 use fastembed::{
-    get_cache_dir, Pooling, QuantizationMode, TextEmbedding, TokenizerFiles,
+    get_cache_dir, Error, Pooling, QuantizationMode, Result, TextEmbedding, TokenizerFiles,
     UserDefinedEmbeddingModel,
 };
 
@@ -32,7 +32,7 @@ fn pull_model(
     model_name: &str,
     output: &PathBuf,
     pooling: Option<Pooling>,
-) -> anyhow::Result<TextEmbedding> {
+) -> Result<TextEmbedding> {
     eprintln!("Pulling {model_name} from the Hugging Face Hub...");
     process::Command::new("optimum-cli")
         .args(&[
@@ -46,20 +46,22 @@ fn pull_model(
                 .expect("Failed to convert path to string"),
         ])
         .output()
-        .map_err(|e| anyhow::anyhow!("Failed to pull model: {}", e))?;
+        .map_err(|e| Error::Other(format!("Failed to pull model: {e}")))?;
 
     load_model(output, pooling)
 }
 
 /// Load bytes from a file, with a nicer error message.
-fn load_bytes_from_file(path: &PathBuf) -> anyhow::Result<Vec<u8>> {
-    std::fs::read(path).map_err(|e| anyhow::anyhow!("Failed to read file at {:?}: {}", path, e))
+fn load_bytes_from_file(path: &PathBuf) -> io::Result<Vec<u8>> {
+    std::fs::read(path)
+        .map_err(|e| io::Error::new(e.kind(), format!("Failed to read file at {path:?}: {e}")))
 }
 
 /// Load a model from a local directory.
-fn load_model(output: &PathBuf, pooling: Option<Pooling>) -> anyhow::Result<TextEmbedding> {
+fn load_model(output: &PathBuf, pooling: Option<Pooling>) -> Result<TextEmbedding> {
     let model = UserDefinedEmbeddingModel {
         onnx_file: load_bytes_from_file(&output.join("model.onnx"))?,
+        external_initializers: Vec::new(),
         tokenizer_files: TokenizerFiles {
             tokenizer_file: load_bytes_from_file(&output.join("tokenizer.json"))?,
             config_file: load_bytes_from_file(&output.join("config.json"))?,
@@ -68,6 +70,7 @@ fn load_model(output: &PathBuf, pooling: Option<Pooling>) -> anyhow::Result<Text
         },
         pooling,
         quantization: QuantizationMode::None,
+        output_key: None,
     };
 
     TextEmbedding::try_new_from_user_defined(model, Default::default())
@@ -99,6 +102,7 @@ macro_rules! create_test {
             let model = load_model(&output, $pooling).unwrap_or_else(|_| {
                 pull_model(&model_name, &output, $pooling).expect("Failed to pull model")
             });
+            let mut model = model;
 
             let documents = vec![
                 "Hello, World!",


### PR DESCRIPTION
Resolves #189 

`anyhow` leaves the dependency tree.

`thiserror = "2"` is a `derive`-only proc-macro. Consumers see the generated `fastembed::Error` enum and its stdlib
trait impls. `thiserror` does not appear in the `cargo tree`.


[NEW DOCUMENTATION ON ERROR HANDLING](https://github.com/Anush008/fastembed-rs#error-handling) 