### PR TITLE
feat: opt-in constant input shape for compiling execution providers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,8 @@ pub use crate::models::text_embedding::EmbeddingModel;
 #[deprecated(note = "use `TextInitOptions` instead")]
 pub use crate::text_embedding::TextInitOptions as InitOptions;
 pub use crate::text_embedding::{
-    InitOptionsUserDefined, TextEmbedding, TextInitOptions, UserDefinedEmbeddingModel,
+    FixedBatchShape, InitOptionsUserDefined, TextEmbedding, TextInitOptions,
+    UserDefinedEmbeddingModel,
 };
 
 // For Sparse Text Embedding

--- a/src/output/embedding_output.rs
+++ b/src/output/embedding_output.rs
@@ -13,6 +13,13 @@ use super::{OutputKey, OutputPrecedence};
 pub struct SingleBatchOutput {
     pub outputs: Vec<(String, ort::value::Value)>,
     pub attention_mask_array: Array2<i64>,
+    /// How many LEADING rows of the batch correspond to real inputs.
+    ///
+    /// Normally equal to the batch height. It is smaller when a constant input
+    /// shape ([`crate::FixedBatchShape`]) is in effect and the last batch was
+    /// padded up to that shape. Consumers MUST drop the tail: padding rows are
+    /// not data, and their embeddings correspond to nothing in the input.
+    pub real_rows: usize,
 }
 
 impl SingleBatchOutput {

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -15,12 +15,13 @@ use ndarray::Array;
 use ort::{session::Session, value::Value};
 #[cfg(feature = "hf-hub")]
 use std::path::PathBuf;
-use tokenizers::Tokenizer;
+use tokenizers::{PaddingStrategy, Tokenizer, TruncationParams};
 
 #[cfg(feature = "hf-hub")]
 use super::TextInitOptions;
 use super::{
-    output, InitOptionsUserDefined, TextEmbedding, UserDefinedEmbeddingModel, DEFAULT_BATCH_SIZE,
+    output, FixedBatchShape, InitOptionsUserDefined, TextEmbedding, UserDefinedEmbeddingModel,
+    DEFAULT_BATCH_SIZE,
 };
 
 impl TextEmbedding {
@@ -142,7 +143,97 @@ impl TextEmbedding {
             pooling: post_process,
             quantization,
             output_key,
+            fixed_shape: None,
         }
+    }
+
+    /// Pin the model input shape to `shape.rows` x `shape.seq_len`.
+    ///
+    /// Two things change: the tokenizer pads to EXACTLY `seq_len` (instead of
+    /// "the longest sequence in the batch"), and a partial last batch is padded
+    /// up to `rows` rows. None of this is visible to the caller — the padding
+    /// rows are dropped through [`SingleBatchOutput::real_rows`], so there is
+    /// still exactly one embedding per input text.
+    ///
+    /// # When this is needed
+    /// Compiling execution providers (MIGraphX and friends) compile kernels per
+    /// input shape, and every new shape costs tens of seconds and hundreds of
+    /// megabytes of on-disk cache. On CPU there is nothing to win — the shape is
+    /// free there, and the padding rows would just burn cycles.
+    ///
+    /// # Errors
+    /// - [`QuantizationMode::Dynamic`] — dynamic quantization refits the data
+    ///   range per batch, which is why batching is disallowed for such models in
+    ///   the first place; there is no batch height to pin.
+    /// - `seq_len` above the tokenizer truncation limit: a longer sequence would
+    ///   be truncated anyway, so the promised shape would not be delivered.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use fastembed::{FixedBatchShape, TextEmbedding};
+    /// # fn main() -> fastembed::Result<()> {
+    /// let model = TextEmbedding::try_new(Default::default())?
+    ///     .with_fixed_batch_shape(FixedBatchShape { rows: 32, seq_len: 512 })?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_fixed_batch_shape(mut self, shape: FixedBatchShape) -> Result<Self> {
+        if shape.rows == 0 || shape.seq_len == 0 {
+            return Err(Error::InvalidArgument(
+                "Fixed batch shape requires non-zero rows and seq_len.".into(),
+            ));
+        }
+        if self.quantization == QuantizationMode::Dynamic {
+            return Err(Error::InvalidArgument(
+                "Fixed batch shape cannot be used with dynamic quantization: \
+                 the data range is refitted per batch, so batching is disallowed \
+                 for such models in the first place."
+                    .into(),
+            ));
+        }
+
+        // Truncation: the shape is only reachable if the tokenizer never emits a
+        // sequence longer than `seq_len`. The limit is set by `load_tokenizer`
+        // (max_length, clamped to the model's model_max_length), so we CHECK it
+        // here rather than raise it — otherwise we would silently promise a shape
+        // wider than the model can take.
+        let truncation_limit = self
+            .tokenizer
+            .get_truncation()
+            .map(|params| params.max_length)
+            .ok_or_else(|| {
+                Error::TokenizerConfig(
+                    "Tokenizer has no truncation params; cannot fix the input shape.".into(),
+                )
+            })?;
+        if shape.seq_len > truncation_limit {
+            return Err(Error::InvalidArgument(format!(
+                "Fixed seq_len {} exceeds the tokenizer truncation limit {truncation_limit}.",
+                shape.seq_len
+            )));
+        }
+
+        let mut padding = self.tokenizer.get_padding().cloned().ok_or_else(|| {
+            Error::TokenizerConfig(
+                "Tokenizer has no padding params; cannot fix the input shape.".into(),
+            )
+        })?;
+        padding.strategy = PaddingStrategy::Fixed(shape.seq_len);
+        self.tokenizer.with_padding(Some(padding));
+        self.tokenizer
+            .with_truncation(Some(TruncationParams {
+                max_length: shape.seq_len,
+                ..Default::default()
+            }))
+            .map_err(|e| Error::TokenizerConfig(e.to_string()))?;
+
+        self.fixed_shape = Some(shape);
+        Ok(self)
+    }
+
+    /// The constant input shape, if one is pinned.
+    pub fn fixed_batch_shape(&self) -> Option<FixedBatchShape> {
+        self.fixed_shape
     }
     /// Return the TextEmbedding model's directory from cache or remote retrieval
     #[cfg(feature = "hf-hub")]
@@ -356,6 +447,14 @@ impl TextEmbedding {
             ));
         }
 
+        // A constant input shape dictates the batch height: the chunks have to be
+        // cut by `rows` exactly, otherwise padding would not help — the chunks
+        // would still arrive with different heights. The caller-supplied
+        // batch_size is deliberately ignored here: the shape is a property of the
+        // model, not of an individual call.
+        let fixed_shape = self.fixed_shape;
+        let batch_size = fixed_shape.map_or(batch_size, |shape| shape.rows);
+
         let batches = texts
             .chunks(batch_size)
             .map(|batch| {
@@ -368,7 +467,27 @@ impl TextEmbedding {
 
                 // Extract the encoding length and batch size
                 let encoding_length = encodings.first().ok_or(Error::EmptyTokenizations)?.len();
-                let batch_size = batch.len();
+                let real_rows = batch.len();
+                // Tensor height: always `rows` under a constant shape, otherwise
+                // as many rows as there are texts in the chunk.
+                let batch_size = fixed_shape.map_or(real_rows, |shape| shape.rows);
+
+                // Shape oracle: the sequence length must be exactly what
+                // `with_fixed_batch_shape` promised. If the tokenizer produced a
+                // different one (the `tokenizer` field is public, so the padding
+                // strategy could have been changed from the outside), failing here
+                // is better than paying for a kernel compilation of an unexpected
+                // shape.
+                if let Some(shape) = fixed_shape {
+                    if encoding_length != shape.seq_len {
+                        return Err(Error::InvalidShape(format!(
+                            "Fixed batch shape promised seq_len {}, but the tokenizer \
+                             produced {encoding_length}; the padding strategy was \
+                             changed externally.",
+                            shape.seq_len
+                        )));
+                    }
+                }
 
                 let max_size = encoding_length * batch_size;
 
@@ -386,6 +505,18 @@ impl TextEmbedding {
                     mask_array.extend(mask.iter().map(|x| *x as i64));
                     type_ids_array.extend(type_ids.iter().map(|x| *x as i64));
                 });
+
+                // Pad the partial chunk up to the constant height. A padding row
+                // is a COPY of the last real row rather than zeros: a copy has a
+                // non-empty attention mask, so mean pooling over it does not
+                // divide by zero. Its embedding is dropped through `real_rows`
+                // anyway.
+                for _ in real_rows..batch_size {
+                    let last = encodings.last().ok_or(Error::EmptyTokenizations)?;
+                    ids_array.extend(last.get_ids().iter().map(|x| *x as i64));
+                    mask_array.extend(last.get_attention_mask().iter().map(|x| *x as i64));
+                    type_ids_array.extend(last.get_type_ids().iter().map(|x| *x as i64));
+                }
 
                 let inputs_ids_array =
                     Array::from_shape_vec((batch_size, encoding_length), ids_array)
@@ -419,6 +550,7 @@ impl TextEmbedding {
                 Ok(SingleBatchOutput {
                     outputs: outputs_map,
                     attention_mask_array,
+                    real_rows,
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/text_embedding/init.rs
+++ b/src/text_embedding/init.rs
@@ -137,6 +137,29 @@ impl UserDefinedEmbeddingModel {
     }
 }
 
+/// A constant input shape for the model: batch rows x sequence length.
+///
+/// # Why
+/// By default the input shape floats on BOTH axes: the tokenizer pads to the
+/// longest sequence *in the batch* (`PaddingStrategy::BatchLongest`), and the
+/// last batch is usually partial. That is free on CPU, but compiling execution
+/// providers (MIGraphX and other AOT backends) compile *kernels per shape*:
+/// every new shape costs a separate compilation (tens of seconds) and a
+/// separate cache file (hundreds of megabytes). Measured while indexing a
+/// 40-file codebase: 4 distinct shapes, 659 MB of kernel cache.
+///
+/// With the shape pinned there is exactly one compilation; the price is the
+/// padding rows computed in the partial last batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixedBatchShape {
+    /// Batch height. Inputs are chunked by `rows`, and the last chunk is padded
+    /// up to `rows` (the padding rows are dropped from the output).
+    pub rows: usize,
+    /// Sequence length. The tokenizer pads to EXACTLY this, not to the longest
+    /// sequence in the batch.
+    pub seq_len: usize,
+}
+
 /// Rust representation of the TextEmbedding model
 pub struct TextEmbedding {
     pub tokenizer: Tokenizer,
@@ -145,4 +168,8 @@ pub struct TextEmbedding {
     pub(crate) need_token_type_ids: bool,
     pub(crate) quantization: QuantizationMode,
     pub(crate) output_key: Option<OutputKey>,
+    /// The constant input shape, if one was requested through
+    /// [`TextEmbedding::with_fixed_batch_shape`]. `None` keeps the previous
+    /// behaviour (the shape floats on both axes).
+    pub(crate) fixed_shape: Option<FixedBatchShape>,
 }

--- a/src/text_embedding/output.rs
+++ b/src/text_embedding/output.rs
@@ -41,6 +41,11 @@ pub fn transformer_with_precedence(
                         array
                             .rows()
                             .into_iter()
+                            // Drop the padding-row tail (constant input
+                            // shape): it corresponds to nothing in the
+                            // input, so exactly as many embeddings come
+                            // out as there were texts.
+                            .take(batch.real_rows)
                             .map(|row| {
                                 row.as_slice()
                                     .ok_or_else(|| {

--- a/tests/text-embeddings.rs
+++ b/tests/text-embeddings.rs
@@ -6,10 +6,10 @@ use std::path::Path;
 use hf_hub::Repo;
 
 use fastembed::{
-    get_cache_dir, Embedding, EmbeddingModel, InitOptions, InitOptionsUserDefined, OnnxSource,
-    Pooling, QuantizationMode, RerankInitOptions, RerankInitOptionsUserDefined, RerankerModel,
-    RerankerModelInfo, SparseInitOptions, SparseTextEmbedding, TextEmbedding, TextRerank,
-    TokenizerFiles, UserDefinedEmbeddingModel, UserDefinedRerankingModel,
+    get_cache_dir, Embedding, EmbeddingModel, FixedBatchShape, InitOptions, InitOptionsUserDefined,
+    OnnxSource, Pooling, QuantizationMode, RerankInitOptions, RerankInitOptionsUserDefined,
+    RerankerModel, RerankerModelInfo, SparseInitOptions, SparseTextEmbedding, TextEmbedding,
+    TextRerank, TokenizerFiles, UserDefinedEmbeddingModel, UserDefinedRerankingModel,
 };
 
 /// A small epsilon value for floating point comparisons.
@@ -520,6 +520,93 @@ fn test_batch_size_does_not_change_output() {
     for (a, b) in single_batch.into_iter().zip(small_batch.into_iter()) {
         assert!(a == b, "Expect each sentence embedding are equal.");
     }
+}
+
+/// A pinned input shape must not change the numbers, and must not leak the
+/// padding rows: 5 texts at `rows: 4` is deliberately not a multiple, so the
+/// last batch is padded and the count would be wrong if the tail escaped.
+#[test]
+fn test_fixed_batch_shape_preserves_embeddings() {
+    let sentences = vec![
+        "Books are no more threatened by Kindle than stairs by elevators.",
+        "You are who you are when nobody's watching.",
+        "An original idea. That can't be too hard. The library must be full of them.",
+        "Gaia visited her daughter Mnemosyne, who was busy being unpronounceable.",
+        "You can never be overdressed or overeducated.",
+    ];
+
+    // Reference: the very same model without a pinned shape.
+    let mut reference = TextEmbedding::try_new(
+        InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_max_length(384),
+    )
+    .expect("Create model successfully");
+    let expected = reference
+        .embed(sentences.clone(), Some(4))
+        .expect("embed successfully");
+
+    let mut model = TextEmbedding::try_new(
+        InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_max_length(384),
+    )
+    .expect("Create model successfully")
+    .with_fixed_batch_shape(FixedBatchShape {
+        rows: 4,
+        seq_len: 384,
+    })
+    .expect("Pin the input shape successfully");
+    assert_eq!(
+        model.fixed_batch_shape(),
+        Some(FixedBatchShape {
+            rows: 4,
+            seq_len: 384
+        })
+    );
+
+    // `batch_size` is deliberately ignored once a shape is pinned.
+    let actual = model
+        .embed(sentences.clone(), Some(3))
+        .expect("embed successfully");
+
+    assert_eq!(actual.len(), sentences.len(), "padding rows leaked out");
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(a.len(), b.len(), "dimension mismatch at {idx}");
+        let cosine: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        assert!(
+            cosine > 0.999,
+            "embedding {idx} changed under a pinned shape: cosine {cosine}"
+        );
+    }
+}
+
+/// Shapes that cannot be delivered are rejected instead of being quietly
+/// adjusted.
+#[test]
+fn test_fixed_batch_shape_rejects_impossible_shapes() {
+    let model = TextEmbedding::try_new(
+        InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_max_length(384),
+    )
+    .expect("Create model successfully");
+
+    let zero = TextEmbedding::try_new(
+        InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_max_length(384),
+    )
+    .expect("Create model successfully")
+    .with_fixed_batch_shape(FixedBatchShape {
+        rows: 0,
+        seq_len: 384,
+    });
+    assert!(zero.is_err(), "zero rows must be rejected");
+
+    // Above the tokenizer truncation limit: the sequence would be truncated
+    // anyway, so the promised shape could not be delivered.
+    let too_long = model.with_fixed_batch_shape(FixedBatchShape {
+        rows: 4,
+        seq_len: 385,
+    });
+    assert!(
+        too_long.is_err(),
+        "seq_len above the truncation limit must be rejected"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

By default the input shape floats on **both** axes: the tokenizer pads to the longest sequence *in the batch* (`PaddingStrategy::BatchLongest`), and the last batch is usually partial.

That is free on CPU. It is not free on compiling execution providers — MIGraphX, and AOT backends in general compile **kernels per input shape**, so every new shape costs a fresh compilation and a separate on-disk cache entry.

Measured while indexing a 40-file Rust codebase through the MIGraphX EP on an AMD RX 7700 XT (gfx1101), BGE-small fp32:

| | before | after |
|---|---|---|
| distinct shapes per indexing run | 4 | 1 |
| kernel cache on disk | 659 MB | 192 MB |
| kernel compilations | 4 x 45–70 s | 1 |
| embedding phase | 60.2 chunks/s | **197 chunks/s** |

(For reference, the pure-forward microbenchmark ceiling for this model at 32x512 on the same GPU is 242 seq/s — so after pinning, the shape is no longer where the time goes.)

## What this adds

- `FixedBatchShape { rows, seq_len }` and `TextEmbedding::with_fixed_batch_shape()`. It sets `PaddingStrategy::Fixed(seq_len)` on the tokenizer and pads a partial last batch up to `rows` rows.
  A padding row is a **copy of the last real row**, not zeros: a copy has a non-empty attention mask, so mean pooling over it does not divide by zero.
- `SingleBatchOutput::real_rows` — how many leading rows are real. The tail is dropped in the output transformer, so exactly as many embeddings come out as there were input texts. The field is public on purpose: padding should not be invisible to anyone consuming the raw output via `into_raw()`.
- Rejections instead of silent adjustment — dynamic quantization, zero sizes, and a `seq_len` above the tokenizer truncation limit are errors. Plus an oracle inside `transform`: if the actual sequence length disagrees with the promised one (the `tokenizer` field is public, so the strategy can be changed from the outside), the batch fails rather than paying for a compilation of an unexpected shape.

**Opt-in and additive** — without `with_fixed_batch_shape` nothing changes. No public API is removed or altered; `SingleBatchOutput` gains a field.

```rust
let model = TextEmbedding::try_new(Default::default())?
    .with_fixed_batch_shape(FixedBatchShape { rows: 32, seq_len: 512 })?;
```

## Tests

Two tests in `tests/text-embeddings.rs`, both CPU-only (no GPU needed):

- `test_fixed_batch_shape_preserves_embeddings` — the reference is the same model *without* a pinned shape, so exactly one thing differs. It checks the numbers (cosine > 0.999 per row) **and** the count: 5 texts at `rows: 4` is a deliberate non-multiple, which is where leaked padding rows would show up. Verified as a real oracle by mutation — replacing `.take(batch.real_rows)` with `.take(usize::MAX)` makes it fail.
- `test_fixed_batch_shape_rejects_impossible_shapes` — the rejections are actually rejections.

`cargo fmt --check` clean; `cargo clippy --all-targets` produces no new warnings.
