### PR TITLE
feat: expose ONNX Runtime session config entries through InitOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ let mut model = TextEmbedding::try_new(Default::default())?;
 let mut model = TextEmbedding::try_new(
     TextInitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true).with_intra_threads(4),
 )?;
-// Also available: `.with_session_config(key, value)` to pass raw ONNX Runtime session config entries.
 
 let documents = vec![
     "passage: Hello, World!",

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ let mut model = TextEmbedding::try_new(Default::default())?;
 let mut model = TextEmbedding::try_new(
     TextInitOptions::new(EmbeddingModel::AllMiniLML6V2).with_show_download_progress(true).with_intra_threads(4),
 )?;
+// Also available: `.with_session_config(key, value)` to pass raw ONNX Runtime session config entries.
 
 let documents = vec![
     "passage: Hello, World!",

--- a/src/bgem3_embedding/impl.rs
+++ b/src/bgem3_embedding/impl.rs
@@ -35,6 +35,7 @@ impl Bgem3Embedding {
             show_download_progress,
             execution_providers,
             intra_threads,
+            session_config,
         } = options;
 
         let model_repo = Bgem3Embedding::retrieve_model(
@@ -63,7 +64,7 @@ impl Bgem3Embedding {
             }
         }
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_file(model_file_reference)?;
 
         let tokenizer = load_tokenizer_hf_hub(model_repo, max_length)?;
@@ -79,10 +80,11 @@ impl Bgem3Embedding {
             execution_providers,
             max_length,
             intra_threads,
+            session_config,
             ..
         } = options;
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_memory(&model.onnx_file)?;
 
         let tokenizer = load_tokenizer(model.tokenizer_files, max_length)?;
@@ -100,10 +102,11 @@ impl Bgem3Embedding {
             execution_providers,
             max_length,
             intra_threads,
+            session_config,
             ..
         } = options;
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_file(model_path.as_ref().join("model.onnx"))?;
 
         let tokenizer = load_tokenizer(tokenizer_files, max_length)?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -266,6 +266,7 @@ pub fn pull_from_hf(
 pub(crate) fn init_session_builder(
     execution_providers: Vec<ExecutionProviderDispatch>,
     intra_threads: Option<usize>,
+    session_config: Vec<(String, String)>,
 ) -> Result<SessionBuilder> {
     let threads = match intra_threads {
         Some(n) => n,
@@ -288,6 +289,12 @@ pub(crate) fn init_session_builder(
         .map_err(builder_error)?
         .with_intra_threads(threads)
         .map_err(builder_error)?;
+
+    for (key, value) in session_config {
+        builder = builder
+            .with_config_entry(&key, &value)
+            .map_err(builder_error)?;
+    }
 
     if has_directml {
         builder = builder
@@ -361,5 +368,14 @@ mod tests {
             err.to_string().contains("model_max_length"),
             "error message was: {err}"
         );
+    }
+    #[test]
+    fn init_session_builder_applies_config_entry() {
+        let builder = init_session_builder(
+            vec![],
+            Some(1),
+            vec![("session.disable_prepacking".into(), "1".into())],
+        );
+        assert!(builder.is_ok());
     }
 }

--- a/src/image_embedding/impl.rs
+++ b/src/image_embedding/impl.rs
@@ -35,6 +35,7 @@ impl ImageEmbedding {
             cache_dir,
             show_download_progress,
             intra_threads,
+            session_config,
         } = options;
 
         let model_repo = ImageEmbedding::retrieve_model(
@@ -61,7 +62,7 @@ impl ImageEmbedding {
                     source: Box::new(e),
                 })?;
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_file(model_file_reference)?;
 
         Ok(Self::new(preprocessor, session))
@@ -77,11 +78,12 @@ impl ImageEmbedding {
         let ImageInitOptionsUserDefined {
             execution_providers,
             intra_threads,
+            session_config,
         } = options;
 
         let preprocessor = Compose::from_bytes(model.preprocessor_file)?;
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_memory(&model.onnx_file)?;
 
         Ok(Self::new(preprocessor, session))

--- a/src/image_embedding/init.rs
+++ b/src/image_embedding/init.rs
@@ -16,6 +16,10 @@ pub struct ImageInitOptionsUserDefined {
     /// every available CPU core via `std::thread::available_parallelism`.
     /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
     pub intra_threads: Option<usize>,
+    /// ONNX Runtime session configuration entries, applied with
+    /// `SessionBuilder::with_config_entry`. Use this for settings that have
+    /// no dedicated builder method, such as `mlas.disable_kleidiai`.
+    pub session_config: Vec<(String, String)>,
 }
 
 impl ImageInitOptionsUserDefined {
@@ -38,6 +42,14 @@ impl ImageInitOptionsUserDefined {
         self.intra_threads = Some(intra_threads);
         self
     }
+
+    /// Add an ONNX Runtime session configuration entry, applied with
+    /// `SessionBuilder::with_config_entry`. Call it once per entry.
+    /// Example: `.with_session_config("mlas.disable_kleidiai", "1")`.
+    pub fn with_session_config(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.session_config.push((key.into(), value.into()));
+        self
+    }
 }
 
 /// Convert ImageInitOptions to ImageInitOptionsUserDefined
@@ -48,6 +60,7 @@ impl From<ImageInitOptions> for ImageInitOptionsUserDefined {
         ImageInitOptionsUserDefined {
             execution_providers: options.execution_providers,
             intra_threads: options.intra_threads,
+            session_config: options.session_config,
         }
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -18,6 +18,10 @@ pub struct InitOptionsWithLength<M> {
     /// every available CPU core via `std::thread::available_parallelism`.
     /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
     pub intra_threads: Option<usize>,
+    /// ONNX Runtime session configuration entries, applied with
+    /// `SessionBuilder::with_config_entry`. Use this for settings that have
+    /// no dedicated builder method, such as `mlas.disable_kleidiai`.
+    pub session_config: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -31,6 +35,10 @@ pub struct InitOptions<M> {
     /// every available CPU core via `std::thread::available_parallelism`.
     /// Set this to cap CPU usage (e.g. on laptops) at the cost of throughput.
     pub intra_threads: Option<usize>,
+    /// ONNX Runtime session configuration entries, applied with
+    /// `SessionBuilder::with_config_entry`. Use this for settings that have
+    /// no dedicated builder method, such as `mlas.disable_kleidiai`.
+    pub session_config: Vec<(String, String)>,
 }
 
 impl<M: Default + HasMaxLength> Default for InitOptionsWithLength<M> {
@@ -42,6 +50,7 @@ impl<M: Default + HasMaxLength> Default for InitOptionsWithLength<M> {
             show_download_progress: true,
             max_length: M::MAX_LENGTH,
             intra_threads: None,
+            session_config: Vec::new(),
         }
     }
 }
@@ -54,6 +63,7 @@ impl<M: Default> Default for InitOptions<M> {
             cache_dir: get_cache_dir().into(),
             show_download_progress: true,
             intra_threads: None,
+            session_config: Vec::new(),
         }
     }
 }
@@ -96,6 +106,14 @@ impl<M: Default + HasMaxLength> InitOptionsWithLength<M> {
         self
     }
 
+    /// Add an ONNX Runtime session configuration entry, applied with
+    /// `SessionBuilder::with_config_entry`. Call it once per entry.
+    /// Example: `.with_session_config("mlas.disable_kleidiai", "1")`.
+    pub fn with_session_config(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.session_config.push((key.into(), value.into()));
+        self
+    }
+
     /// Set whether to show download progress
     pub fn with_show_download_progress(mut self, show_download_progress: bool) -> Self {
         self.show_download_progress = show_download_progress;
@@ -132,6 +150,14 @@ impl<M: Default> InitOptions<M> {
     /// usage at the cost of per-inference throughput.
     pub fn with_intra_threads(mut self, intra_threads: usize) -> Self {
         self.intra_threads = Some(intra_threads);
+        self
+    }
+
+    /// Add an ONNX Runtime session configuration entry, applied with
+    /// `SessionBuilder::with_config_entry`. Call it once per entry.
+    /// Example: `.with_session_config("mlas.disable_kleidiai", "1")`.
+    pub fn with_session_config(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.session_config.push((key.into(), value.into()));
         self
     }
 

--- a/src/reranking/impl.rs
+++ b/src/reranking/impl.rs
@@ -52,6 +52,7 @@ impl TextRerank {
             cache_dir,
             show_download_progress,
             intra_threads,
+            session_config,
         } = options;
 
         let model_repo = pull_from_hf(model_name.to_string(), cache_dir, show_download_progress)?;
@@ -75,7 +76,7 @@ impl TextRerank {
                     })?;
         }
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_file(model_file_reference)?;
 
         let tokenizer = load_tokenizer_hf_hub(model_repo, max_length)?;
@@ -95,9 +96,11 @@ impl TextRerank {
             intra_threads,
             disable_cpu_fallback,
             dimension_overrides,
+            session_config,
         } = options;
 
-        let mut session_builder = init_session_builder(execution_providers, intra_threads)?;
+        let mut session_builder =
+            init_session_builder(execution_providers, intra_threads, session_config)?;
         let builder_error = |err: ort::Error<ort::session::builder::SessionBuilder>| {
             Error::OrtBuilder(err.to_string())
         };

--- a/src/reranking/init.rs
+++ b/src/reranking/init.rs
@@ -39,6 +39,10 @@ pub struct RerankInitOptionsUserDefined {
     /// Override named free dimensions before ORT optimizes and places the
     /// user-defined reranker graph.
     pub dimension_overrides: Vec<(String, i64)>,
+    /// ONNX Runtime session configuration entries, applied with
+    /// `SessionBuilder::with_config_entry`. Use this for settings that have
+    /// no dedicated builder method, such as `mlas.disable_kleidiai`.
+    pub session_config: Vec<(String, String)>,
 }
 
 impl Default for RerankInitOptionsUserDefined {
@@ -49,6 +53,7 @@ impl Default for RerankInitOptionsUserDefined {
             intra_threads: None,
             disable_cpu_fallback: false,
             dimension_overrides: Vec::new(),
+            session_config: Vec::new(),
         }
     }
 }
@@ -90,6 +95,14 @@ impl RerankInitOptionsUserDefined {
         self.dimension_overrides.push((name.into(), size));
         self
     }
+
+    /// Add an ONNX Runtime session configuration entry, applied with
+    /// `SessionBuilder::with_config_entry`. Call it once per entry.
+    /// Example: `.with_session_config("mlas.disable_kleidiai", "1")`.
+    pub fn with_session_config(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.session_config.push((key.into(), value.into()));
+        self
+    }
 }
 
 /// Convert RerankInitOptions to RerankInitOptionsUserDefined
@@ -103,6 +116,7 @@ impl From<RerankInitOptions> for RerankInitOptionsUserDefined {
             intra_threads: options.intra_threads,
             disable_cpu_fallback: false,
             dimension_overrides: Vec::new(),
+            session_config: options.session_config,
         }
     }
 }
@@ -170,5 +184,22 @@ mod tests {
         assert_eq!(o.intra_threads, Some(2));
         assert!(o.disable_cpu_fallback);
         assert_eq!(o.dimension_overrides, vec![("sequence_length".into(), 128)]);
+    }
+
+    #[test]
+    fn session_config_is_collected_and_carried_by_from() {
+        let opts = RerankInitOptions::new(RerankerModel::default())
+            .with_session_config("a", "1")
+            .with_session_config("b", "2");
+        assert_eq!(
+            opts.session_config,
+            vec![("a".into(), "1".into()), ("b".into(), "2".into())]
+        );
+
+        let user_defined = RerankInitOptionsUserDefined::from(opts);
+        assert_eq!(
+            user_defined.session_config,
+            vec![("a".into(), "1".into()), ("b".into(), "2".into())]
+        );
     }
 }

--- a/src/sparse_text_embedding/impl.rs
+++ b/src/sparse_text_embedding/impl.rs
@@ -36,6 +36,7 @@ impl SparseTextEmbedding {
             show_download_progress,
             execution_providers,
             intra_threads,
+            session_config,
         } = options;
 
         let model_repo = SparseTextEmbedding::retrieve_model(
@@ -64,7 +65,7 @@ impl SparseTextEmbedding {
             }
         }
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_file(model_file_reference)?;
 
         let tokenizer = load_tokenizer_hf_hub(model_repo, max_length)?;

--- a/src/text_embedding/impl.rs
+++ b/src/text_embedding/impl.rs
@@ -38,6 +38,7 @@ impl TextEmbedding {
             cache_dir,
             show_download_progress,
             intra_threads,
+            session_config,
         } = options;
 
         let model_repo = TextEmbedding::retrieve_model(
@@ -68,7 +69,7 @@ impl TextEmbedding {
         // prioritise loading pooling config if available, if not (thanks qdrant!), look for it in hardcoded
         let post_processing = TextEmbedding::get_default_pooling_method(&model_name);
 
-        let session = init_session_builder(execution_providers, intra_threads)?
+        let session = init_session_builder(execution_providers, intra_threads, session_config)?
             .commit_from_file(model_file_reference)?;
 
         let tokenizer = load_tokenizer_hf_hub(model_repo, max_length)?;
@@ -94,13 +95,15 @@ impl TextEmbedding {
             intra_threads,
             disable_cpu_fallback,
             dimension_overrides,
+            session_config,
         } = options;
 
         let session = {
             let builder_error = |err: ort::Error<ort::session::builder::SessionBuilder>| {
                 Error::OrtBuilder(err.to_string())
             };
-            let mut session_builder = init_session_builder(execution_providers, intra_threads)?;
+            let mut session_builder =
+                init_session_builder(execution_providers, intra_threads, session_config)?;
 
             if disable_cpu_fallback {
                 session_builder = session_builder

--- a/src/text_embedding/init.rs
+++ b/src/text_embedding/init.rs
@@ -39,6 +39,10 @@ pub struct InitOptionsUserDefined {
     /// graph. Static-shape execution providers such as QNN can use this with
     /// one user-defined model session per admitted shape.
     pub dimension_overrides: Vec<(String, i64)>,
+    /// ONNX Runtime session configuration entries, applied with
+    /// `SessionBuilder::with_config_entry`. Use this for settings that have
+    /// no dedicated builder method, such as `mlas.disable_kleidiai`.
+    pub session_config: Vec<(String, String)>,
 }
 
 impl InitOptionsUserDefined {
@@ -78,6 +82,14 @@ impl InitOptionsUserDefined {
         self.dimension_overrides.push((name.into(), size));
         self
     }
+
+    /// Add an ONNX Runtime session configuration entry, applied with
+    /// `SessionBuilder::with_config_entry`. Call it once per entry.
+    /// Example: `.with_session_config("mlas.disable_kleidiai", "1")`.
+    pub fn with_session_config(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.session_config.push((key.into(), value.into()));
+        self
+    }
 }
 
 impl Default for InitOptionsUserDefined {
@@ -88,6 +100,7 @@ impl Default for InitOptionsUserDefined {
             intra_threads: None,
             disable_cpu_fallback: false,
             dimension_overrides: Vec::new(),
+            session_config: Vec::new(),
         }
     }
 }
@@ -103,6 +116,7 @@ impl From<TextInitOptions> for InitOptionsUserDefined {
             intra_threads: options.intra_threads,
             disable_cpu_fallback: false,
             dimension_overrides: Vec::new(),
+            session_config: options.session_config,
         }
     }
 }
@@ -190,6 +204,23 @@ mod tests {
                 ("batch_size".to_string(), 1),
                 ("sequence_length".to_string(), 512)
             ]
+        );
+    }
+
+    #[test]
+    fn session_config_is_collected_and_carried_by_from() {
+        let opts = TextInitOptions::new(EmbeddingModel::AllMiniLML6V2)
+            .with_session_config("a", "1")
+            .with_session_config("b", "2");
+        assert_eq!(
+            opts.session_config,
+            vec![("a".into(), "1".into()), ("b".into(), "2".into())]
+        );
+
+        let user_defined = InitOptionsUserDefined::from(opts);
+        assert_eq!(
+            user_defined.session_config,
+            vec![("a".into(), "1".into()), ("b".into(), "2".into())]
         );
     }
 }


### PR DESCRIPTION
Closes #291.

## What changed

- `init_session_builder` takes a `session_config: Vec<(String, String)>` parameter. It applies each entry with `SessionBuilder::with_config_entry` after `with_intra_threads`. The DirectML block is unchanged.
- `InitOptions<M>` and `InitOptionsWithLength<M>` gain a `session_config` field and a `with_session_config(key, value)` builder method. The default is empty.
- `InitOptionsUserDefined`, `RerankInitOptionsUserDefined`, and `ImageInitOptionsUserDefined` gain the same field and method. The `From` impls copy the field.
- All ten `init_session_builder` call sites pass the field through.
- README: one line next to the `with_intra_threads` example.

## Why

Some ONNX Runtime behaviors have a per-session switch only. `mlas.disable_kleidiai` is one example. On Apple Silicon with SME, ONNX Runtime 1.28.0 keeps packed GEMM buffers in thread-local storage. The buffers never shrink. A long-lived process retains gigabytes after one embedding pass. With `with_session_config("mlas.disable_kleidiai", "1")` the same process retains 216 MB instead of 2189 MB. See #291 and microsoft/onnxruntime#29538.

The shape follows the existing `execution_providers` and `intra_threads` passthroughs.

## Usage

```rust
let model = TextEmbedding::try_new(
    TextInitOptions::new(EmbeddingModel::SnowflakeArcticEmbedS)
        .with_session_config("mlas.disable_kleidiai", "1"),
)?;
```

## Tests

- `init_session_builder_applies_config_entry` calls the real `SessionBuilder` with one entry and asserts success. It loads no model.
- Unit tests assert that `with_session_config` appends in order and that the `From` impls carry the field.
- `cargo fmt --all -- --check`, `cargo clippy ... -- -D warnings`, and `cargo test --lib` pass with `ort-download-binaries-native-tls,hf-hub-native-tls`.

## Compatibility

The option structs are `#[non_exhaustive]`, so the new field is not a breaking change for callers that use the builder methods. Callers that construct the structs by field name inside this crate are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
